### PR TITLE
DRD-31: connect mautic to frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,13 +1,16 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Druid - Team 4</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+
 </html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.7.7",
+        "mautic-tracking": "^0.9.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.27.0"
@@ -3121,6 +3122,11 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/mautic-tracking": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/mautic-tracking/-/mautic-tracking-0.9.3.tgz",
+      "integrity": "sha512-EGGsTavWZAI1XnoyUMwmIZoar/rv+Foej2rj2DlpsYQx/LloMXydMSDXJCTaH9M18/aabI60zGSDg54KZt9e8g=="
     },
     "node_modules/mime-db": {
       "version": "1.52.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "mautic-tracking": "^0.9.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,4 @@
+import mautic from "./services/mautic";
 import { Routes, Route, useLocation } from "react-router-dom";
 import About from "./pages/About";
 import Layout from "./pages/Layout";
@@ -6,16 +7,29 @@ import Services from "./pages/Services";
 import Jobs from "./pages/Jobs";
 import Blog from "./pages/Blog";
 import FrontPage from "./pages/FrontPage";
-import mautic from "./services/mautic";
 import { useEffect } from "react";
 
 const App = () => {
   const location = useLocation();
 
-  // Track page views whenever the route changes
   useEffect(() => {
-    // Track page views when the location changes
-    mautic.pageView({ path: location.pathname });
+    // Change page title according to path
+    const pageTitles = {
+      "/": "Homepage | Druid - Team 4",
+      "/services": "Our Services | Druid Team 4",
+      "/contact": "Contact | Druid Team 4",
+      "/about": "About Us | Druid Team 4",
+      "/blog": "Blog | Druid Team 4",
+      "/jobs": "Jobs | Druid Team 4",
+    };
+    const title = pageTitles[location.pathname] || "Druid - Team 4";
+    document.title = title;
+
+    // Track the page view
+    mautic.pageView({
+      path: location.pathname,
+      title: document.title,
+    });
   }, [location]);
 
   return (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { Routes, Route, useLocation } from "react-router-dom";
 import About from "./pages/About";
 import Layout from "./pages/Layout";
 import Contact from "./pages/Contact";
@@ -6,21 +6,29 @@ import Services from "./pages/Services";
 import Jobs from "./pages/Jobs";
 import Blog from "./pages/Blog";
 import FrontPage from "./pages/FrontPage";
+import mautic from "./services/mautic";
+import { useEffect } from "react";
 
 const App = () => {
+  const location = useLocation();
+
+  // Track page views whenever the route changes
+  useEffect(() => {
+    // Track page views when the location changes
+    mautic.pageView({ path: location.pathname });
+  }, [location]);
+
   return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={<FrontPage />} />
-          <Route path="/services" element={<Services />} />
-          <Route path="/contact" element={<Contact />} />
-          <Route path="/about" element={<About />} />
-          <Route path="/jobs" element={<Jobs />} />
-          <Route path="/blog" element={<Blog />} />
-        </Route>
-      </Routes>
-    </Router>
+    <Routes>
+      <Route path="/" element={<Layout />}>
+        <Route index element={<FrontPage />} />
+        <Route path="/services" element={<Services />} />
+        <Route path="/contact" element={<Contact />} />
+        <Route path="/about" element={<About />} />
+        <Route path="/jobs" element={<Jobs />} />
+        <Route path="/blog" element={<Blog />} />
+      </Route>
+    </Routes>
   );
 };
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App.jsx'
-import './index.css'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.jsx";
+import "./index.css";
+import { BrowserRouter } from "react-router-dom";
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </StrictMode>
+);

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { fetchContent, localhostAddress } from "../services/api";
+import { fetchContent, drupalLocalhostAddress } from "../services/api";
 
 const About = () => {
   const [content, setContent] = useState(null);
@@ -35,7 +35,7 @@ const About = () => {
   // Find the image file in included data based on the ID
   const imageFile = included?.find((image) => image.id === imageData?.id);
   const imageUrl = imageFile
-    ? `${localhostAddress}${imageFile.attributes.uri.url}`
+    ? `${drupalLocalhostAddress}${imageFile.attributes.uri.url}`
     : null;
 
   return (

--- a/frontend/src/services/api.jsx
+++ b/frontend/src/services/api.jsx
@@ -1,7 +1,7 @@
 import axios from "axios";
 
-const localhostAddress = "http://localhost:56050"; // Update this if your localhost address changes. No trailing forward slash.
-const API_URL = `${localhostAddress}/jsonapi`;
+const drupalLocalhostAddress = "http://localhost:56050"; // Update this if your Drupal localhost address changes. No trailing forward slash.
+const API_URL = `${drupalLocalhostAddress}/jsonapi`;
 
 export const fetchContent = async (contentType) => {
   try {
@@ -14,4 +14,4 @@ export const fetchContent = async (contentType) => {
   }
 };
 
-export { localhostAddress };
+export { drupalLocalhostAddress };

--- a/frontend/src/services/api.jsx
+++ b/frontend/src/services/api.jsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const drupalLocalhostAddress = "http://localhost:56050"; // Update this if your Drupal localhost address changes. No trailing forward slash.
+const drupalLocalhostAddress = "http://localhost:53144"; // Update this if your Drupal localhost address changes. No trailing forward slash.
 const API_URL = `${drupalLocalhostAddress}/jsonapi`;
 
 export const fetchContent = async (contentType) => {

--- a/frontend/src/services/mautic.jsx
+++ b/frontend/src/services/mautic.jsx
@@ -1,0 +1,9 @@
+import mautic from "mautic-tracking";
+
+// Replace with your Mautic instance's localhost address. Omit trailing forward slash.
+const mauticUrl = "http://localhost:62208";
+
+// Initialize the Mautic Tracking
+mautic.initialize(`${mauticUrl}/mtc.js`);
+
+export default mautic;

--- a/frontend/src/services/mautic.jsx
+++ b/frontend/src/services/mautic.jsx
@@ -1,7 +1,7 @@
 import mautic from "mautic-tracking";
 
 // Replace with your Mautic instance's localhost address. Omit trailing forward slash.
-const mauticUrl = "http://localhost:62208";
+const mauticUrl = "http://localhost:61722";
 
 // Initialize the Mautic Tracking
 mautic.initialize(`${mauticUrl}/mtc.js`);


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-31](https://edu-team4-react24k.atlassian.net/browse/DRD-31?atlOrigin=eyJpIjoiOWJjZjI0ZTZjYThmNGMwNmFjMDhjODEzYzYwZGYyOTgiLCJwIjoiaiJ9)

## In this PR:
- Connected Mautic instance to React frontend
- Notice: currently only the first homepage hit is logged. We want the different page visits to be tracked, but I couldn't figure this out yet. I will create a new ticket for this.

## Testing instructions:
- Checkout branch
- Do npm install in frontend (new dependency: mautic-tracking)
- Insert the localhost address your Mautic instance is running on to:

1. `frontend/src/services/mautic.jsx` line 4 - mauticUrl
2. `mautic-lando/config/local.php` line 14 - site_url

- Make sure your Mautic has the following configurations (cogwheel in top right corner -> Configuration):

1. API Settings -> API enabled -> Yes
2. System Settings -> CORS Settings -> Restrict Domains -> No
3. Tracking Settings -> identify visitor by tracking url -> Yes
4. identify visitors by IP -> Yes

- On react site: Click around the different pages
- On Mautic left panel click Contacts
- You may have to click "Toggle anonymous contacts" on the right
- You should now see tracked contacts
- Open one to see tracked events


![Screenshot 2024-10-25 at 13 15 09](https://github.com/user-attachments/assets/fdf4f050-3915-4ac7-bee3-7469fba20bfe)


[DRD-31]: https://edu-team4-react24k.atlassian.net/browse/DRD-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ