### PR TITLE
DRD-58: Move localhostadresses to an env file

### DIFF
--- a/frontend/src/pages/Blog.jsx
+++ b/frontend/src/pages/Blog.jsx
@@ -112,7 +112,7 @@ const Blog = () => {
                 ></div>
                 <button className="text-gray-200">Read More</button>
               </ProseWrapper>
-              <hr class="h-px my-8 bg-gray-200 border-0 dark:bg-gray-200"></hr>
+              <hr className="h-px my-8 bg-gray-200 border-0 dark:bg-gray-200"></hr>
             </div>
           ))
         ) : (

--- a/frontend/src/services/api.jsx
+++ b/frontend/src/services/api.jsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const drupalLocalhostAddress = "http://localhost:63683"; // Update this if your Drupal localhost address changes. No trailing forward slash.
+const drupalLocalhostAddress = import.meta.env.VITE_DRUPAL_BASE_URL;
 const API_URL = `${drupalLocalhostAddress}/jsonapi`;
 
 export const fetchContent = async (contentType) => {

--- a/frontend/src/services/mautic.jsx
+++ b/frontend/src/services/mautic.jsx
@@ -1,7 +1,6 @@
 import mautic from "mautic-tracking";
 
-// Replace with your Mautic instance's localhost address. Omit trailing forward slash.
-const mauticUrl = "http://localhost:51920";
+const mauticUrl = import.meta.env.VITE_MAUTIC_BASE_URL;
 
 // Initialize the Mautic Tracking
 mautic.initialize(`${mauticUrl}/mtc.js`);


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-58](https://edu-team4-react24k.atlassian.net/browse/DRD-58?atlOrigin=eyJpIjoiM2JjMzY1N2NjZjQ3NDljOWEwMjhlN2U4YTg1MGU5YmYiLCJwIjoiaiJ9)
## In this PR:
- Replaced hard coded localhostaddresses with ones from env file
- Renamed hr tag "class" to "className" in Blog.jsx
## Testing instructions:
- Checkout branch
- Create .env file in `frontend`:
```bash
VITE_DRUPAL_BASE_URL=http://localhost:YOURPORTHERE
VITE_MAUTIC_BASE_URL=http://localhost:YOURPORTHERE
```
- Don't include forward slash after port
- Stop frontend (Ctrl + C in vite terminal)
- `npm run dev`
- check that content is coming in from drupal and mautic tracking works
- **Notice** you still need to make sure the mautic address is correct in `mautic-lando/config/local.php` (after you restart mautic container for example)

[DRD-58]: https://edu-team4-react24k.atlassian.net/browse/DRD-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ