### PR TITLE
DRD-55: Add individual Service pages to the frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -42,7 +42,7 @@ const App = () => {
         <Route path="/about" element={<About />} />
         <Route path="/jobs" element={<Jobs />} />
         <Route path="/blog" element={<Blog />} />
-        <Route path="/service/:serviceType/:serviceId" element={<ServiceDetail />} />
+        <Route path="/service/:serviceType" element={<ServiceDetail />} />
       </Route>
     </Routes>
   );

--- a/frontend/src/pages/OurServices.jsx
+++ b/frontend/src/pages/OurServices.jsx
@@ -73,7 +73,7 @@ const OurServices = () => {
           </h1>
           {items.map((item) => (
             <div key={item.id} className="service-item mb-8">
-              <Link to={`/service/${serviceType}/${item.id}`} className="block">
+              <Link to={`/service/${serviceType}`} className="block">
                 {item.heroImageUrl && (
                   <div>
                     <HeroImage src={item.heroImageUrl} />
@@ -91,6 +91,7 @@ const OurServices = () => {
                       __html: item.sanitizedLongDescription,
                     }}
                   />
+                  <a href="/">Read more</a>
                 </ProseWrapper>
               </Link>
             </div>


### PR DESCRIPTION
## Related ticket
[DRD-55](https://edu-team4-react24k.atlassian.net/jira/software/projects/DRD/boards/1?selectedIssue=DRD-55)

## In this PR:
- Fixed routing in App.jsx to direct to the component ServiceDetail.jsx
- OurServices.jsx component edited to link to /service/serviceType, i.e. /service/consultation or whatever service type
- Added a Read more link
- Used existing component ServiceDetail.jsx to display the single page for each service listed on OurServices.jsx

## Testing instructions: 
- checkout branch
- go to the Services page in the frontend
- check that Read more link works after every service type (should go to /service/project or /service/maintenance or /service/consultation)
- check that images and content are loading with no error messages
