### PR TITLE
DRD-65: Services page: Display one title + short description per section

### DIFF
--- a/frontend/src/pages/OurServices.jsx
+++ b/frontend/src/pages/OurServices.jsx
@@ -67,10 +67,6 @@ const OurServices = () => {
     <Section>
       {Object.entries(services).map(([serviceType, items]) => (
         <section key={serviceType} className="mb-12">
-          <h1 className="text-2xl font-bold mb-4">
-            {serviceType.charAt(0).toUpperCase() + serviceType.slice(1)}{" "}
-            Services
-          </h1>
           {items.map((item) => (
             <div key={item.id} className="service-item mb-8">
               <Link to={`/service/${serviceType}`} className="block">
@@ -82,16 +78,10 @@ const OurServices = () => {
                 )}
 
                 <ProseWrapper>
-                  <p className="text-gray-700 mb-2">
+                  <p className="text-gray-700 mb-2 prose">
                     {item.attributes.field_short_description}
                   </p>
-                  <div
-                    className="prose" // Apply Tailwind typography styles here
-                    dangerouslySetInnerHTML={{
-                      __html: item.sanitizedLongDescription,
-                    }}
-                  />
-                  <a href="/">Read more</a>
+                  <a href={`/service/${serviceType}`}>Read more</a>
                 </ProseWrapper>
               </Link>
             </div>

--- a/frontend/src/pages/ServiceDetail.jsx
+++ b/frontend/src/pages/ServiceDetail.jsx
@@ -41,7 +41,7 @@ const ServiceDetail = () => {
     return <p>This page is unavailable at the moment. Try again later.</p>;
 
   // Sanitize the body content
-  const sanitizedBodyContent = DOMPurify.sanitize(
+  const sanitizedLongDescContent = DOMPurify.sanitize(
     service.attributes.field_long_description?.value
   );
 
@@ -60,7 +60,9 @@ const ServiceDetail = () => {
           />
         )}
         <ProseWrapper>
-          <div dangerouslySetInnerHTML={{ __html: sanitizedBodyContent }}></div>
+          <div
+            dangerouslySetInnerHTML={{ __html: sanitizedLongDescContent }}
+          ></div>
         </ProseWrapper>
       </Section>
     </div>


### PR DESCRIPTION
## Related ticket
[DRD-65](https://edu-team4-react24k.atlassian.net/jira/software/projects/DRD/boards/1?selectedIssue=DRD-65)

## In this PR:
- removed one heading from OurServices.jsx
- removed long description from OurServices.jsx

## Testing instructions
- checkout branch
- go to services page, there should only be one title under hero image and short description 
<img width="878" alt="Screenshot 2024-11-11 at 14 04 55" src="https://github.com/user-attachments/assets/e7bacd68-afd8-450a-8a5e-11e7a73ad44c">


[DRD-65]: https://edu-team4-react24k.atlassian.net/browse/DRD-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ