### PR TITLE
DRD-73: Fix "<a> cannot appear as a descendant of <a>" on Services page

### DIFF
--- a/frontend/src/pages/OurServices.jsx
+++ b/frontend/src/pages/OurServices.jsx
@@ -78,11 +78,9 @@ const OurServices = () => {
                 )}
 
                 <ProseWrapper>
-                  <p className="text-gray-700 mb-2 prose">
-                    {item.attributes.field_short_description}
-                  </p>
-                  <a href={`/service/${serviceType}`}>Read more</a>
+                  {item.attributes.field_short_description}
                 </ProseWrapper>
+                <span className="block underline mt-2">Read more</span>
               </Link>
             </div>
           ))}


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-73](https://edu-team4-react24k.atlassian.net/browse/DRD-73?atlOrigin=eyJpIjoiYTdhN2VjYTUyOGFjNGE0MzlkMDBiMGVlYTUxMWJhNzYiLCJwIjoiaiJ9)
## In this PR:
- Replaced nested `<a>` tag with span, removed `<p>` tags from short description (redundant because it's already inside ProseWrapper)
- Moved "Read more span" outside ProseWrapper
## Testing instructions:
- Checkout branch
- Check you get no console error on Services page
- Check links to individual service pages still work



[DRD-73]: https://edu-team4-react24k.atlassian.net/browse/DRD-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ