### PR TITLE
DRD-81: ProjectCasePage - display image paragraph + text with image paragraph

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -33,6 +33,7 @@ export default [
         'warn',
         { allowConstantExport: true },
       ],
+      "react/prop-types": "off"
     },
   },
 ]

--- a/frontend/src/components/ImageParagraph.jsx
+++ b/frontend/src/components/ImageParagraph.jsx
@@ -1,0 +1,22 @@
+import { findImageUrl } from "../services/utils";
+
+const ImageParagraph = ({ paragraph, included }) => {
+  const imageUrl = findImageUrl(paragraph.relationships?.field_image, included);
+
+  return (
+    <div>
+      <h3 className="font-semibold">
+        {paragraph.attributes?.field_heading || ""}
+      </h3>
+      {imageUrl && (
+        <img
+          src={imageUrl}
+          alt={paragraph.attributes?.field_heading || "Project image"}
+          className="mt-4 max-w-full h-auto rounded-lg shadow-md"
+        />
+      )}
+    </div>
+  );
+};
+
+export default ImageParagraph;

--- a/frontend/src/components/ParagraphRenderer.jsx
+++ b/frontend/src/components/ParagraphRenderer.jsx
@@ -1,0 +1,26 @@
+import TextParagraph from "./TextParagraph";
+import ImageParagraph from "./ImageParagraph";
+import TextWithImageParagraph from "./TextWithImageParagraph";
+
+const ParagraphRenderer = ({ paragraph, included, findImageUrl }) => {
+  const paragraphComponents = {
+    "paragraph--text": TextParagraph,
+    "paragraph--image": ImageParagraph,
+    "paragraph--text_with_image": TextWithImageParagraph,
+  };
+
+  const Component = paragraphComponents[paragraph.type];
+  if (!Component) return null;
+
+  return (
+    <div className="mt-8">
+      <Component
+        paragraph={paragraph}
+        included={included}
+        findImageUrl={findImageUrl}
+      />
+    </div>
+  );
+};
+
+export default ParagraphRenderer;

--- a/frontend/src/components/ParagraphRenderer.jsx
+++ b/frontend/src/components/ParagraphRenderer.jsx
@@ -2,7 +2,7 @@ import TextParagraph from "./TextParagraph";
 import ImageParagraph from "./ImageParagraph";
 import TextWithImageParagraph from "./TextWithImageParagraph";
 
-const ParagraphRenderer = ({ paragraph, included, findImageUrl }) => {
+const ParagraphRenderer = ({ paragraph, included }) => {
   const paragraphComponents = {
     "paragraph--text": TextParagraph,
     "paragraph--image": ImageParagraph,
@@ -16,11 +16,7 @@ const ParagraphRenderer = ({ paragraph, included, findImageUrl }) => {
 
   return (
     <div className="mt-8">
-      <Component
-        paragraph={paragraph}
-        included={included}
-        findImageUrl={findImageUrl}
-      />
+      <Component paragraph={paragraph} included={included} />
     </div>
   );
 };

--- a/frontend/src/components/ParagraphRenderer.jsx
+++ b/frontend/src/components/ParagraphRenderer.jsx
@@ -9,6 +9,8 @@ const ParagraphRenderer = ({ paragraph, included, findImageUrl }) => {
     "paragraph--text_with_image": TextWithImageParagraph,
   };
 
+  console.log("Rendering paragraph:", paragraph.type, paragraph);
+
   const Component = paragraphComponents[paragraph.type];
   if (!Component) return null;
 

--- a/frontend/src/components/TextParagraph.jsx
+++ b/frontend/src/components/TextParagraph.jsx
@@ -1,0 +1,22 @@
+import ProseWrapper from "../components/ProseWrapper";
+import DOMPurify from "dompurify";
+
+const TextParagraph = ({ content }) => {
+  if (!content || !content.field_heading || !content.field_text) {
+    return null;
+  }
+
+  return (
+    <ProseWrapper>
+      <h3 className="font-semibold">{content.field_heading}</h3>
+      <div
+        className="prose"
+        dangerouslySetInnerHTML={{
+          __html: DOMPurify.sanitize(content.field_text.value),
+        }}
+      />
+    </ProseWrapper>
+  );
+};
+
+export default TextParagraph;

--- a/frontend/src/components/TextParagraph.jsx
+++ b/frontend/src/components/TextParagraph.jsx
@@ -1,18 +1,25 @@
 import ProseWrapper from "../components/ProseWrapper";
 import DOMPurify from "dompurify";
 
-const TextParagraph = ({ content }) => {
-  if (!content || !content.field_heading || !content.field_text) {
+const TextParagraph = ({ paragraph }) => {
+  if (
+    !paragraph ||
+    // !paragraph.attributes.field_heading ||
+    !paragraph.attributes.field_text
+  ) {
+    console.log("Invalid content for TextParagraph:", paragraph);
     return null;
   }
 
   return (
     <ProseWrapper>
-      <h3 className="font-semibold">{content.field_heading}</h3>
+      {paragraph.attributes.field_heading && (
+        <h3 className="font-semibold">{paragraph.attributes.field_heading}</h3>
+      )}{" "}
       <div
         className="prose"
         dangerouslySetInnerHTML={{
-          __html: DOMPurify.sanitize(content.field_text.value),
+          __html: DOMPurify.sanitize(paragraph.attributes.field_text.processed),
         }}
       />
     </ProseWrapper>

--- a/frontend/src/components/TextWithImageParagraph.jsx
+++ b/frontend/src/components/TextWithImageParagraph.jsx
@@ -4,8 +4,20 @@ import { findImageUrl } from "../services/utils";
 const TextWithImageParagraph = ({ paragraph, included }) => {
   const imageUrl = findImageUrl(paragraph.relationships?.field_image, included);
 
+  // Check if toggle "field_image_first" is set to true or false by user in drupal paragraph:
+  const isImageFirst = paragraph.attributes?.field_image_first || false;
+
   return (
     <div className="flex flex-col md:flex-row items-center gap-6">
+      {isImageFirst && imageUrl && (
+        <div className="md:w-1/2">
+          <img
+            src={imageUrl}
+            alt={paragraph.attributes?.field_heading || "Project image"}
+            className="max-w-full h-auto rounded-lg shadow-md"
+          />
+        </div>
+      )}
       <div className="md:w-1/2">
         <h3 className="font-semibold">
           {paragraph.attributes?.field_heading || ""}
@@ -13,19 +25,19 @@ const TextWithImageParagraph = ({ paragraph, included }) => {
         <div
           className="prose"
           dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(paragraph.attributes?.field_text?.value),
+            __html: DOMPurify.sanitize(paragraph.attributes?.field_long_text),
           }}
         />
       </div>
-      <div className="md:w-1/2">
-        {imageUrl && (
+      {!isImageFirst && imageUrl && (
+        <div className="md:w-1/2">
           <img
             src={imageUrl}
             alt={paragraph.attributes?.field_heading || "Project image"}
             className="max-w-full h-auto rounded-lg shadow-md"
           />
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/TextWithImageParagraph.jsx
+++ b/frontend/src/components/TextWithImageParagraph.jsx
@@ -1,0 +1,33 @@
+import DOMPurify from "dompurify";
+import { findImageUrl } from "../services/utils";
+
+const TextWithImageParagraph = ({ paragraph, included }) => {
+  const imageUrl = findImageUrl(paragraph.relationships?.field_image, included);
+
+  return (
+    <div className="flex flex-col md:flex-row items-center gap-6">
+      <div className="md:w-1/2">
+        <h3 className="font-semibold">
+          {paragraph.attributes?.field_heading || ""}
+        </h3>
+        <div
+          className="prose"
+          dangerouslySetInnerHTML={{
+            __html: DOMPurify.sanitize(paragraph.attributes?.field_text?.value),
+          }}
+        />
+      </div>
+      <div className="md:w-1/2">
+        {imageUrl && (
+          <img
+            src={imageUrl}
+            alt={paragraph.attributes?.field_heading || "Project image"}
+            className="max-w-full h-auto rounded-lg shadow-md"
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TextWithImageParagraph;

--- a/frontend/src/pages/ProjectCasePage.jsx
+++ b/frontend/src/pages/ProjectCasePage.jsx
@@ -1,23 +1,33 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { drupalLocalhostAddress } from "../services/api";
-import ProseWrapper from "../components/ProseWrapper";
-import DOMPurify from "dompurify";
+import ParagraphRenderer from "../components/ParagraphRenderer";
+import Section from "../components/Section";
+import HeroImage from "../components/HeroImage";
+import SectionHeading from "../components/SectionHeading";
 
 const ProjectCasePage = () => {
-  const { companyName } = useParams(); // Extract company name from URL
+  // companyName is used as the path to individual project
+  const { companyName } = useParams();
   const [project, setProject] = useState(null);
+  const [included, setIncluded] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     const fetchProjectDetail = async () => {
       try {
+        setLoading(true);
         const response = await fetch(
-          `${drupalLocalhostAddress}/jsonapi/node/project_case?include=field_heroimg,field_content`
+          `${drupalLocalhostAddress}/jsonapi/node/project_case?include=field_heroimg,field_content.field_image.field_media_image`
         );
         const data = await response.json();
 
+        if (!response.ok) {
+          throw new Error("Failed to fetch project data");
+        }
+
         if (data.data) {
-          // Find the project with a matching company name
           const projectDetail = data.data.find(
             (project) =>
               project.attributes.field_customer
@@ -25,136 +35,108 @@ const ProjectCasePage = () => {
                 .replace(/\s+/g, "-") === companyName
           );
 
-          if (projectDetail) {
-            const { title, field_customer, field_project_description } =
-              projectDetail.attributes;
-
-            const heroImageId =
-              projectDetail.relationships.field_heroimg?.data?.id;
-            const heroImage = data.included?.find(
-              (img) => img.id === heroImageId && img.type === "file--file"
-            );
-            const heroImageUrl = heroImage
-              ? `${drupalLocalhostAddress}${heroImage.attributes.uri.url}`
-              : null;
-
-            const paragraphs = projectDetail.relationships.field_content?.data
-              ?.map((content) => {
-                const paragraphData = data.included?.find(
-                  (item) =>
-                    item.id === content.id &&
-                    item.type.startsWith("paragraph--")
-                );
-                return paragraphData
-                  ? {
-                      type: paragraphData.type,
-                      content: paragraphData.attributes,
-                    }
-                  : null;
-              })
-              .filter(Boolean);
-
-            setProject({
-              title,
-              customer: field_customer,
-              description: field_project_description,
-              heroImageUrl,
-              paragraphs,
-            });
-          } else {
-            console.error("Project not found for company:", companyName);
+          if (!projectDetail) {
+            throw new Error(`Project not found for company: ${companyName}`);
           }
+
+          const { title, field_customer, field_project_description } =
+            projectDetail.attributes;
+
+          // Find hero image
+          const heroImageId =
+            projectDetail.relationships.field_heroimg?.data?.id;
+          const heroImage = data.included?.find(
+            (img) => img.id === heroImageId && img.type === "file--file"
+          );
+          const heroImageUrl = heroImage
+            ? `${drupalLocalhostAddress}${heroImage.attributes.uri.url}`
+            : null;
+
+          // Process paragraphs while keeping the full paragraph data
+          const paragraphs = projectDetail.relationships.field_content?.data
+            ?.map((content) => {
+              const paragraphData = data.included?.find(
+                (item) =>
+                  item.id === content.id && item.type.startsWith("paragraph--")
+              );
+              return paragraphData
+                ? {
+                    type: paragraphData.type,
+                    attributes: paragraphData.attributes,
+                    relationships: paragraphData.relationships,
+                  }
+                : null;
+            })
+            .filter(Boolean);
+
+          setProject({
+            title,
+            customer: field_customer,
+            description: field_project_description,
+            heroImageUrl,
+            paragraphs,
+          });
+          setIncluded(data.included || []);
         }
       } catch (error) {
         console.error("Error fetching project detail:", error);
+        setError(error.message);
+      } finally {
+        setLoading(false);
       }
     };
 
     fetchProjectDetail();
-  }, [companyName]); // Re-fetch when companyName changes
+  }, [companyName]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-lg">Loading...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-lg text-red-600">{error}</div>
+      </div>
+    );
+  }
 
   if (!project) {
-    return <div>Loading...</div>;
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-lg">Project not found</div>
+      </div>
+    );
   }
 
   return (
-    <div className="container mx-auto p-6">
-      <div className="bg-white p-6 rounded-lg shadow-lg">
-        {project.heroImageUrl && (
-          <img
-            src={project.heroImageUrl}
-            alt={project.title}
-            className="w-full h-64 object-cover rounded-t-lg"
+    <Section>
+      {" "}
+      {project.heroImageUrl && (
+        <HeroImage src={project.heroImageUrl} alt={project.title} />
+      )}
+      <header className="mb-8">
+        <SectionHeading>{project.customer}</SectionHeading>
+        <h2 className="text-xl font-semibold">{project.title}</h2>
+
+        <p className="mt-4 text-gray-700 leading-relaxed">
+          {project.description}
+        </p>
+      </header>
+      <div className="space-y-8">
+        {project.paragraphs?.map((paragraph, index) => (
+          <ParagraphRenderer
+            key={index}
+            paragraph={paragraph}
+            included={included}
           />
-        )}
-        <h1 className="text-3xl font-semibold mt-4">{project.title}</h1>
-        <h2 className="text-lg text-gray-500">{project.customer}</h2>
-        <p className="mt-4">{project.description}</p>
-
-        <div className="mt-6">
-          {project.paragraphs?.map((paragraph, index) => (
-            <div key={index} className="mt-4">
-              {/* Handle paragraph types */}
-
-              {/* Text paragraph */}
-              {paragraph.type === "paragraph--text" && (
-                <ProseWrapper>
-                  <h3 className="font-semibold">
-                    {paragraph.content.field_heading}
-                  </h3>
-                  <div
-                    className="prose"
-                    dangerouslySetInnerHTML={{
-                      __html: DOMPurify.sanitize(
-                        paragraph.content.field_text?.value
-                      ),
-                    }}
-                  />
-                  {/* Text content */}
-                </ProseWrapper>
-              )}
-
-              {/* Image paragraph */}
-              {paragraph.type === "paragraph--image" && (
-                <div>
-                  <h3 className="font-semibold">
-                    {paragraph.content.field_heading}
-                  </h3>
-                  {paragraph.content.field_image?.uri?.url && (
-                    <img
-                      src={`${drupalLocalhostAddress}${paragraph.content.field_image.uri.url}`}
-                      alt={paragraph.content.field_heading}
-                      className="mt-4 max-w-full h-auto"
-                    />
-                  )}
-                </div>
-              )}
-
-              {/* Text + Image paragraph */}
-              {paragraph.type === "paragraph--text_with_image" && (
-                <div className="flex flex-col md:flex-row items-center mt-4">
-                  <div className="md:w-1/2">
-                    <h3 className="font-semibold">
-                      {paragraph.content.field_heading}
-                    </h3>
-                    <p>{paragraph.content.field_text?.value}</p>
-                  </div>
-                  <div className="md:w-1/2 mt-4 md:mt-0">
-                    {paragraph.content.field_image?.uri?.url && (
-                      <img
-                        src={`${drupalLocalhostAddress}${paragraph.content.field_image.uri.url}`}
-                        alt={paragraph.content.field_heading}
-                        className="max-w-full h-auto"
-                      />
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
+        ))}
       </div>
-    </div>
+    </Section>
   );
 };
 

--- a/frontend/src/services/utils.js
+++ b/frontend/src/services/utils.js
@@ -1,0 +1,29 @@
+import { drupalLocalhostAddress } from "./api";
+
+export const findImageUrl = (fieldImage, included) => {
+    if (!fieldImage || !included) return null;
+  
+    // Get the media entity ID from the paragraph's field_image relationship
+    const mediaEntityId = fieldImage.data?.id;
+    if (!mediaEntityId) return null;
+  
+    // Find the media entity
+    const mediaEntity = included.find(
+      item => item.type === "media--image" && item.id === mediaEntityId
+    );
+    if (!mediaEntity) return null;
+  
+    // Get the file ID from the media entity's field_media_image relationship
+    const fileId = mediaEntity.relationships?.field_media_image?.data?.id;
+    if (!fileId) return null;
+  
+    // Find the file entity
+    const fileEntity = included.find(
+      item => item.type === "file--file" && item.id === fileId
+    );
+    
+    if (fileEntity?.attributes?.uri?.url) {
+      return `${drupalLocalhostAddress}${fileEntity.attributes.uri.url}`;
+    }
+    return null;
+  };


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-81](https://edu-team4-react24k.atlassian.net/browse/DRD-81?atlOrigin=eyJpIjoiZGQ3MDc5NDZjYzIwNDA0NmI4ZTViMjU2NzAxMGY4YWIiLCJwIjoiaiJ9)
## In this PR:
- Created components ParagraphRenderer, TextParagraph, ImageParagraph, TextWithImageParagraph
- Moved function findImageUrl to `services/utils.js`. Can be imported to components as needed.
- Modified eslint config to not warn about "_ missing in props validation" in vscode
- TextWithImageParagraph: implemented "field_image_first" toggle affecting rendered paragraph layout (image on left/right of text)
## Testing instructions:
- Checkout branch
- View individual project case pages on frontend. Each should have paragraph content rendered
- Check you get no browser console errors

## Known issues
- TextWithImageParagraph "title" is not rendered
- No check for "two columns" boolean in TextParagraph implemented yet

[DRD-81]: https://edu-team4-react24k.atlassian.net/browse/DRD-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ