### PR TITLE
DRD-83: Fix <h1> cannot appear as a child of <h1> on Blog page

### DIFF
--- a/frontend/src/pages/Blog.jsx
+++ b/frontend/src/pages/Blog.jsx
@@ -97,20 +97,14 @@ const BlogPost = ({ blog }) => {
   return (
     <Section>
       <div>
-        <SectionHeading>
-          <h1>{blog.title}</h1>
-        </SectionHeading>
+        <SectionHeading>{blog.title}</SectionHeading>
         <p>
           <strong>Author:</strong> {blog.authorName}
         </p>
         <p>
           <strong>Date:</strong> {new Date(blog.date).toLocaleDateString()}
         </p>
-        {blog.mediaUrl && (
-          <div>
-            <HeroImage src={blog.mediaUrl} alt={blog.title} />
-          </div>
-        )}
+        {blog.mediaUrl && <HeroImage src={blog.mediaUrl} alt={blog.title} />}
         <ProseWrapper>
           <h2>Short Description</h2>
           <p>{blog.shortText}</p>


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-83](https://edu-team4-react24k.atlassian.net/browse/DRD-83?atlOrigin=eyJpIjoiMGFlMTFmNTEzYTk0NDVlNWI2NmVmZmUzMTZhYzdhNjIiLCJwIjoiaiJ9)
## In this PR:
- Removed duplicate nested h1 tags
- Removed redundant div
## Testing instructions:
- Checkout branch
- Check browser console on blog page doesn't give error `"<h1> cannot appear as a child of <h1>"`