### PR TITLE
DRD-84: TextParagraph: implement "two-columns" boolean layout change

### DIFF
--- a/frontend/src/components/TextParagraph.jsx
+++ b/frontend/src/components/TextParagraph.jsx
@@ -1,27 +1,74 @@
+import React from "react";
 import ProseWrapper from "../components/ProseWrapper";
 import DOMPurify from "dompurify";
 
 const TextParagraph = ({ paragraph }) => {
-  if (
-    !paragraph ||
-    // !paragraph.attributes.field_heading ||
-    !paragraph.attributes.field_text
-  ) {
+  if (!paragraph || !paragraph.attributes.field_text) {
     console.log("Invalid content for TextParagraph:", paragraph);
     return null;
   }
 
+  // Sanitize the HTML content and create a temporary container to parse it
+  const sanitizedHtml = DOMPurify.sanitize(
+    paragraph.attributes.field_text.processed
+  );
+
+  // Create a temporary div to parse the HTML and select all relevant elements
+  const parsedHtml = new DOMParser().parseFromString(
+    sanitizedHtml,
+    "text/html"
+  );
+
+  // Select the first heading if present
+  const headingElement = parsedHtml.querySelector("h2, h3, h4, h5, h6");
+
+  // Remove the heading element from the parsed HTML body to avoid duplicate rendering
+  if (headingElement) {
+    headingElement.remove();
+  }
+
+  // Select all paragraph elements
+  const paragraphElements = Array.from(parsedHtml.querySelectorAll("p"));
+
+  // Check if two-column layout is enabled
+  const isTwoColumns = paragraph.attributes?.field_two_columns || false;
+
+  // If two columns are enabled, split the paragraphs into two columns
+  let twoColumnLayout = null;
+  if (isTwoColumns && paragraphElements.length > 1) {
+    twoColumnLayout = (
+      <div className="md:grid md:grid-cols-2 md:gap-6 prose">
+        <div>
+          {React.createElement("div", {}, paragraphElements[0].innerHTML)}
+        </div>
+        <div>
+          {React.createElement("div", {}, paragraphElements[1].innerHTML)}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <ProseWrapper>
-      {paragraph.attributes.field_heading && (
-        <h3 className="font-semibold">{paragraph.attributes.field_heading}</h3>
-      )}{" "}
-      <div
-        className="prose"
-        dangerouslySetInnerHTML={{
-          __html: DOMPurify.sanitize(paragraph.attributes.field_text.processed),
-        }}
-      />
+      {/* Render the heading if it exists */}
+      {headingElement &&
+        React.createElement(
+          headingElement.nodeName.toLowerCase(),
+          { className: "font-semibold" },
+          headingElement.innerHTML
+        )}
+
+      {/* Render the remaining content */}
+      {!twoColumnLayout ? (
+        <div
+          className="prose"
+          dangerouslySetInnerHTML={{
+            __html: parsedHtml.body.innerHTML, // Render the original HTML without the heading
+          }}
+        />
+      ) : (
+        twoColumnLayout // If two-column layout is active, render that
+      )}
     </ProseWrapper>
   );
 };


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-84](https://edu-team4-react24k.atlassian.net/browse/DRD-84?atlOrigin=eyJpIjoiZTMyYmU5ZTE0ZTYzNGM1OGE5MGZmODc1YzdiMDcwODAiLCJwIjoiaiJ9)
## In this PR:
- Refactored TextParagraph component to check for boolean "field_two_columns" and change layout of `<p>`s accordingly
## Testing instructions:
- Checkout branch
- See Company C project case page (should have text paragraph with two columns by default, won't have that heading though)
- OR: Edit one of the project cases in Drupal to have a text paragraph with up to: 1 heading, 2 paragraphs in the text input (you can click "Source" on text input toolbar to see the html) + check the box "two-columns"
![Screenshot 2024-11-18 at 15 21 06](https://github.com/user-attachments/assets/ab63d0d0-c8f2-4966-98b4-53ce7f5cad7c)


