### PR TITLE
DRD-88: Mautic API call to check which segments the visitor belongs to

### DIFF
--- a/conf/core.extension.yml
+++ b/conf/core.extension.yml
@@ -1,6 +1,7 @@
 _core:
   default_config_hash: 4GIX5Esnc_umpXUBj4IIocRX7Mt5fPhm4AgXfE3E56E
 module:
+  MauticAPI: 0
   announcements_feed: 0
   automated_cron: 0
   big_pipe: 0
@@ -25,9 +26,12 @@ module:
   history: 0
   image: 0
   jsonapi: 0
+  jsonapi_extras: 0
+  jsonapi_include: 0
   link: 0
   mautic: 0
   mautic_paragraph: 0
+  mautic_proxy: 0
   media: 0
   media_library: 0
   menu_link_content: 0

--- a/conf/jsonapi_extras.settings.yml
+++ b/conf/jsonapi_extras.settings.yml
@@ -1,0 +1,6 @@
+_core:
+  default_config_hash: 4_ifqxmFEAYSrGFkA63fLBYAWO-Fz9ACp9qVjkxPghg
+path_prefix: jsonapi
+include_count: false
+default_disabled: false
+validate_configuration_integrity: true

--- a/conf/jsonapi_include.settings.yml
+++ b/conf/jsonapi_include.settings.yml
@@ -1,0 +1,4 @@
+_core:
+  default_config_hash: oNj_YWRd_RS7gGndiHfMYCWy1weA6vQGhyDbTH6tcqw
+langcode: en
+use_include_query: true

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import OurServices from "./pages/OurServices";
 import ServiceDetail from "./pages/ServiceDetail";
 import ProjectCasePage from "./pages/ProjectCasePage";
 import { capitalizeFirstLetter } from "./services/utils";
+import { fetchContactSegments } from "./services/fetchContactSegments";
 
 const App = () => {
   const location = useLocation();
@@ -52,6 +53,20 @@ const App = () => {
       title: document.title,
     });
   }, [location]);
+
+  // Fetch visitor's segments
+  useEffect(() => {
+    const fetchSegments = async () => {
+      try {
+        const data = await fetchContactSegments();
+        console.log("Contact Segments:", data);
+      } catch (err) {
+        console.error("Error:", err.message);
+      }
+    };
+
+    fetchSegments(); // Run the function when the component mounts
+  }, []); // Empty dependency array, runs once when component mounts
 
   return (
     <Routes>

--- a/frontend/src/services/fetchContactSegments.jsx
+++ b/frontend/src/services/fetchContactSegments.jsx
@@ -1,0 +1,27 @@
+import axios from "axios";
+import { drupalLocalhostAddress } from "../services/api";
+
+// Helper function to get cookie value by name
+export const getCookieValue = (name) => {
+  const cookies = document.cookie.split("; ");
+  const cookie = cookies.find((row) => row.startsWith(name + "="));
+  return cookie ? cookie.split("=")[1] : null;
+};
+
+// Service function to fetch contact segments
+export const fetchContactSegments = async () => {
+  const contactId = getCookieValue("mtc_id");
+
+  if (!contactId) {
+    throw new Error("mtc_id cookie not found.");
+  }
+
+  try {
+    const response = await axios.get(
+      `${drupalLocalhostAddress}/api/mautic/contact/${contactId}`
+    );
+    return response.data; // Returning the response data
+  } catch (err) {
+    throw new Error(`Error fetching contact segments: ${err.message}`);
+  }
+};

--- a/web/modules/custom/mautic_proxy/mautic_proxy.info.yml
+++ b/web/modules/custom/mautic_proxy/mautic_proxy.info.yml
@@ -1,0 +1,7 @@
+name: 'Mautic Proxy'
+type: module
+description: 'Provides a proxy service for Mautic API.'
+core_version_requirement: ^10
+package: Custom
+dependencies:
+  - drupal:serialization

--- a/web/modules/custom/mautic_proxy/mautic_proxy.routing.yml
+++ b/web/modules/custom/mautic_proxy/mautic_proxy.routing.yml
@@ -1,0 +1,7 @@
+mautic_proxy.contact:
+  path: '/api/mautic/contact/{contactId}'
+  defaults:
+    _controller: '\Drupal\mautic_proxy\Controller\MauticController::getContactSegments'
+    _title: 'Get Mautic Contact Segments'
+  requirements:
+    _permission: 'access content'

--- a/web/modules/custom/mautic_proxy/mautic_proxy.services.yml
+++ b/web/modules/custom/mautic_proxy/mautic_proxy.services.yml
@@ -1,0 +1,4 @@
+services:
+  mautic_proxy.mautic_service:
+    class: Drupal\mautic_proxy\Service\MauticService
+    arguments: ['@http_client']

--- a/web/modules/custom/mautic_proxy/src/Controller/MauticController.php
+++ b/web/modules/custom/mautic_proxy/src/Controller/MauticController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\mautic_proxy\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\mautic_proxy\Service\MauticService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class MauticController extends ControllerBase
+{
+    protected $mauticService;
+
+    public function __construct(MauticService $mauticService)
+    {
+        $this->mauticService = $mauticService;
+    }
+
+    public static function create(ContainerInterface $container)
+    {
+        return new static(
+            $container->get('mautic_proxy.mautic_service')
+        );
+    }
+
+    public function getContactSegments($contactId)
+    {
+        try {
+            $contactSegments = $this->mauticService->fetchContactSegments($contactId);
+            return new JsonResponse([
+                'contact_id' => $contactId,
+                'segments' => $contactSegments['lists'] ?? [],
+            ]);
+        } catch (\Exception $e) {
+            return new JsonResponse(['error' => $e->getMessage()], 500);
+        }
+    }
+}

--- a/web/modules/custom/mautic_proxy/src/Service/MauticService.php
+++ b/web/modules/custom/mautic_proxy/src/Service/MauticService.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\mautic_proxy\Service;
+
+use GuzzleHttp\Client;
+
+class MauticService
+{
+    protected $httpClient;
+
+    public function __construct(Client $http_client)
+    {
+        $this->httpClient = $http_client;
+    }
+
+    public function fetchContactSegments($contactId)
+    {
+        $username = $_ENV['API_USER']; // Securely fetch credentials
+        $password = $_ENV['API_KEY'];
+        $mautic_url = 'http://appserver.mauticapp.internal';
+
+        if (!$username || !$password || !$mautic_url) {
+            throw new \Exception('Mautic credentials or base URL are missing in the environment variables.');
+        }
+
+        $auth = base64_encode("$username:$password");
+
+        $response = $this->httpClient->request('GET', "$mautic_url/api/contacts/$contactId/segments", [
+            'headers' => [
+                'Authorization' => 'Basic ' . $auth,
+                'Accept' => 'application/json',
+            ],
+        ]);
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        if (isset($data['lists'])) {
+            return $data;
+        }
+
+        throw new \Exception('No segments found for this contact.');
+
+    }
+}


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-88](https://edu-team4-react24k.atlassian.net/browse/DRD-88?atlOrigin=eyJpIjoiZTY4NWFjYmE2NjMxNDVhOWEyZWZhNzM5NDZjMjJkZmYiLCJwIjoiaiJ9)
## In this PR:
- Created Drupal module mautic_proxy, for making the mauticAPI call to get visitor's segments on backend. This is to prevent mautic credentials from being exposed.
- Created frontend service `fetchContactSegments.jsx`
- Use it in App to console log current visitor's segments
## Testing instructions:
- Checkout branch
- `lando drush cim`
- `lando drush cr`
- Check which contact ID you are browsing as (either in browser tools -> Application -> Cookies -> mtc_id, or you should see a console log with the id if you refresh the frontend)
- Go to mautic -> Contacts -> Open the contact with the ID you are browsing as -> top right corner down arrow -> Preferences -> Segments -> Add contact to one or more segments -> Save
- Refresh frontend, and you should see a console log with the segments
- If this is not working/you get server errors, ensure you have the module "Mautic Proxy" enabled in Drupal

![Screenshot 2024-11-21 at 14 24 47](https://github.com/user-attachments/assets/8eb2b964-ccae-44bf-9e07-e21b06949679)

[DRD-88]: https://edu-team4-react24k.atlassian.net/browse/DRD-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ