### PR TITLE
DRD-89: Refactor ParagraphRenderer to render only the paragraphs visitor is supposed to see

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.3.0",
         "@tailwindcss/typography": "^0.5.15",
         "axios": "^1.7.7",
         "dompurify": "^3.1.7",
@@ -15,6 +16,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.3.0",
+        "react-redux": "^9.1.2",
         "react-router-dom": "^6.27.0"
       },
       "devDependencies": {
@@ -988,6 +990,29 @@
         "node": ">=14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.3.0.tgz",
+      "integrity": "sha512-WC7Yd6cNGfHx8zf+iu+Q1UPTfEcXhQ+ATi7CV1hlrSAaQBdlPzg7Ww/wJHNQem7qG9rxmWoFCDCPubSvFObGzA==",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz",
@@ -1287,13 +1312,13 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
       "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1307,6 +1332,11 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.3",
@@ -1859,7 +1889,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
@@ -2967,6 +2997,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -4201,6 +4240,28 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-redux": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.2.tgz",
+      "integrity": "sha512-0OA4dhM1W48l3uzmv6B7TXPCGmokUU4p1M44DGN2/D9a1FjVPukVjER1PcPX97jIg6aUeLq1XJo1IpfbgULn0w==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25",
+        "react": "^18.0",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -4259,6 +4320,19 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
@@ -4297,6 +4371,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
@@ -4998,6 +5077,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^2.3.0",
     "@tailwindcss/typography": "^0.5.15",
     "axios": "^1.7.7",
     "dompurify": "^3.1.7",
@@ -17,6 +18,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",
+    "react-redux": "^9.1.2",
     "react-router-dom": "^6.27.0"
   },
   "devDependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,9 +11,15 @@ import OurServices from "./pages/OurServices";
 import ServiceDetail from "./pages/ServiceDetail";
 import ProjectCasePage from "./pages/ProjectCasePage";
 import { capitalizeFirstLetter } from "./services/utils";
-import { fetchContactSegments } from "./services/fetchContactSegments";
+import { useDispatch } from "react-redux";
+import { fetchSegments } from "./store/visitorSegmentsSlice";
 
 const App = () => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(fetchSegments());
+  }, [dispatch]);
   const location = useLocation();
 
   useEffect(() => {
@@ -53,20 +59,6 @@ const App = () => {
       title: document.title,
     });
   }, [location]);
-
-  // Fetch visitor's segments
-  useEffect(() => {
-    const fetchSegments = async () => {
-      try {
-        const data = await fetchContactSegments();
-        console.log("Contact Segments:", data);
-      } catch (err) {
-        console.error("Error:", err.message);
-      }
-    };
-
-    fetchSegments(); // Run the function when the component mounts
-  }, []); // Empty dependency array, runs once when component mounts
 
   return (
     <Routes>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,12 +15,13 @@ import { useDispatch } from "react-redux";
 import { fetchSegments } from "./store/visitorSegmentsSlice";
 
 const App = () => {
+  const location = useLocation();
   const dispatch = useDispatch();
 
+  // Fetch user segments on first page load
   useEffect(() => {
     dispatch(fetchSegments());
   }, [dispatch]);
-  const location = useLocation();
 
   useEffect(() => {
     // Define static page titles
@@ -46,7 +47,7 @@ const App = () => {
         decodeURIComponent(serviceType)
       )}  | Druid Team 4`;
     } else {
-      // Use predefined title or fallback
+      // Use predefined title for fallback
       title = pageTitles[location.pathname] || "Druid - Team 4";
     }
 

--- a/frontend/src/components/ParagraphRenderer.jsx
+++ b/frontend/src/components/ParagraphRenderer.jsx
@@ -2,26 +2,118 @@ import TextParagraph from "./TextParagraph";
 import ImageParagraph from "./ImageParagraph";
 import TextWithImageParagraph from "./TextWithImageParagraph";
 import { useSelector } from "react-redux";
+import axios from "axios";
+import { useState, useEffect } from "react";
+
+// Fetch visitor's segments from Redux state
+const useVisitorSegments = () => {
+  return useSelector((state) => state.visitorSegments.data);
+};
+
+// Function to fetch segment details using the provided link
+const fetchSegmentDetails = async (segmentLink) => {
+  try {
+    console.log("Attempting to fetch segment details from:", segmentLink);
+    const response = await axios.get(segmentLink);
+    console.log("Full Segment Response:", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("Detailed Error Fetching Segment Details:", {
+      message: error.message,
+      url: segmentLink,
+      fullError: error,
+    });
+    return { data: [] };
+  }
+};
+
+// Function to check if the visitor qualifies for any segment
+const isVisitorInSegment = (visitorSegments, paragraphSegments) => {
+  const visitorSet = new Set(visitorSegments);
+  return paragraphSegments.some((segment) => visitorSet.has(segment));
+};
 
 const ParagraphRenderer = ({ paragraph, included }) => {
-  
-  const visitorSegments = useSelector((state) => state.visitorSegments.data);
+  const visitorSegments = useVisitorSegments(); // Get visitor's segments from Redux state
+  const visitorSegmentsLoading = useSelector(
+    (state) => state.visitorSegments.isLoading
+  );
+  const visitorSegmentsError = useSelector(
+    (state) => state.visitorSegments.error
+  );
+
+  console.log("Paragraph Rendering Debug:", {
+    paragraphType: paragraph.type,
+    visitorSegments,
+    isLoading: visitorSegmentsLoading,
+    error: visitorSegmentsError,
+  });
+
+  console.log("Visitor Segments State:", {
+    segments: visitorSegments,
+    isLoading: visitorSegmentsLoading,
+  });
+
+  const [paragraphSegments, setParagraphSegments] = useState([]);
+  const [paragraphSegmentsLoading, setParagraphSegmentsLoading] =
+    useState(true);
+
+  // Lookup table to select which component should be rendered by ParagraphRenderer
   const paragraphComponents = {
     "paragraph--text": TextParagraph,
     "paragraph--image": ImageParagraph,
     "paragraph--text_with_image": TextWithImageParagraph,
   };
 
-  console.log("Rendering paragraph:", paragraph.type, paragraph);
+  // Get the segment link from the paragraph
+  const segmentLink =
+    paragraph?.relationships?.field_mautic_segments?.links?.related?.href;
 
+  useEffect(() => {
+    const fetchData = async () => {
+      if (segmentLink) {
+        try {
+          const data = await fetchSegmentDetails(segmentLink);
+          const segmentNames = data.data.map(
+            (segment) => segment.attributes.field_segment_name
+          );
+          setParagraphSegments(segmentNames);
+        } catch (error) {
+          console.error("Failed to fetch segment data:", error);
+          setParagraphSegments([]);
+        } finally {
+          setParagraphSegmentsLoading(false); // Finish loading state for paragraph segments
+        }
+      }
+    };
+
+    fetchData();
+  }, [segmentLink]);
+
+  console.log("Visitor Segments:", visitorSegments);
+  console.log("Paragraph Segments:", paragraphSegments);
+
+  // Check if both visitor and paragraph segments are loaded
+  if (visitorSegmentsLoading || paragraphSegmentsLoading) {
+    return <div>Loading...</div>;
+  }
+
+  // Use the lookup table on line 38 to determine which component to render
   const Component = paragraphComponents[paragraph.type];
   if (!Component) return null;
 
+  // Rendering logic: Show paragraph only if visitor belongs to the segment
+  const shouldRenderParagraph =
+    paragraphSegments.length === 0 || // No segments, render for all
+    isVisitorInSegment(visitorSegments, paragraphSegments);
+
+  if (!shouldRenderParagraph) {
+    console.log(`Paragraph hidden, visitor not in a qualifying segment.`);
+    return null;
+  }
+
   return (
     <div className="mt-8">
-      {visitorSegments.map((segment) => (
-        <p key={segment.id}>{segment.name}</p>
-      ))}
       <Component paragraph={paragraph} included={included} />
     </div>
   );

--- a/frontend/src/components/ParagraphRenderer.jsx
+++ b/frontend/src/components/ParagraphRenderer.jsx
@@ -1,8 +1,11 @@
 import TextParagraph from "./TextParagraph";
 import ImageParagraph from "./ImageParagraph";
 import TextWithImageParagraph from "./TextWithImageParagraph";
+import { useSelector } from "react-redux";
 
 const ParagraphRenderer = ({ paragraph, included }) => {
+  
+  const visitorSegments = useSelector((state) => state.visitorSegments.data);
   const paragraphComponents = {
     "paragraph--text": TextParagraph,
     "paragraph--image": ImageParagraph,
@@ -16,6 +19,9 @@ const ParagraphRenderer = ({ paragraph, included }) => {
 
   return (
     <div className="mt-8">
+      {visitorSegments.map((segment) => (
+        <p key={segment.id}>{segment.name}</p>
+      ))}
       <Component paragraph={paragraph} included={included} />
     </div>
   );

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,11 +3,15 @@ import { createRoot } from "react-dom/client";
 import App from "./App.jsx";
 import "./index.css";
 import { BrowserRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import { store } from "./store/store";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <Provider store={store}>
+        <App />
+      </Provider>
     </BrowserRouter>
   </StrictMode>
 );

--- a/frontend/src/pages/ProjectCasePage.jsx
+++ b/frontend/src/pages/ProjectCasePage.jsx
@@ -130,7 +130,7 @@ const ProjectCasePage = () => {
       <div className="space-y-8">
         {project.paragraphs?.map((paragraph, index) => (
           <ParagraphRenderer
-            key={index}
+            key={`${paragraph.type}-${index}`}
             paragraph={paragraph}
             included={included}
           />

--- a/frontend/src/services/fetchContactSegments.jsx
+++ b/frontend/src/services/fetchContactSegments.jsx
@@ -12,20 +12,30 @@ export const getCookieValue = (name) => {
 export const fetchContactSegments = async () => {
   const contactId = getCookieValue("mtc_id");
 
+  // If no contactId, return an empty segments object instead of throwing an error
   if (!contactId) {
-    throw new Error("mtc_id cookie not found.");
+    console.warn("mtc_id cookie not found. Returning empty segments.");
+    return { segments: {} };
   }
 
   try {
+    console.log("Fetching contact segments for contactId:", contactId);
     const response = await axios.get(
       `${drupalLocalhostAddress}/api/mautic/contact/${contactId}`
     );
-    // console.log("Raw Response:", response);
-    const data = response.data;
-    // console.log("Parsed Data:", data);
 
-    return data;
+    console.log("Full Segments Response:", response.data);
+
+    // Ensure the response has a segments property
+    if (!response.data.segments) {
+      console.warn("No segments found in response", response.data);
+      return { segments: {} };
+    }
+
+    return response.data;
   } catch (err) {
-    throw new Error(`Error fetching contact segments: ${err.message}`);
+    console.error("Error fetching contact segments:", err);
+    // Return an empty segments object instead of throwing an error
+    return { segments: {} };
   }
 };

--- a/frontend/src/services/fetchContactSegments.jsx
+++ b/frontend/src/services/fetchContactSegments.jsx
@@ -20,7 +20,11 @@ export const fetchContactSegments = async () => {
     const response = await axios.get(
       `${drupalLocalhostAddress}/api/mautic/contact/${contactId}`
     );
-    return response.data; // Returning the response data
+    // console.log("Raw Response:", response);
+    const data = response.data;
+    // console.log("Parsed Data:", data);
+
+    return data;
   } catch (err) {
     throw new Error(`Error fetching contact segments: ${err.message}`);
   }

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -1,0 +1,10 @@
+import { configureStore } from "@reduxjs/toolkit";
+import visitorSegmentsReducer from "./visitorSegmentsSlice";
+
+export const store = configureStore({
+  reducer: {
+    visitorSegments: visitorSegmentsReducer,
+  },
+});
+
+export default store;

--- a/frontend/src/store/visitorSegmentsSlice.js
+++ b/frontend/src/store/visitorSegmentsSlice.js
@@ -1,0 +1,44 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { fetchContactSegments } from "../services/fetchContactSegments";
+
+// Async thunk to fetch contact segments
+export const fetchSegments = createAsyncThunk(
+  "visitorSegments/fetchSegments",
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await fetchContactSegments();
+      const segmentNames = Object.values(response.segments).map((segment) => segment.name);
+      return segmentNames;
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+const visitorSegmentsSlice = createSlice({
+  name: "visitorSegments",
+  initialState: {
+    data: [],
+    isLoading: false,
+    error: null,
+  },
+  reducers: {}, // Optional: add manual reducers if needed
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchSegments.pending, (state) => {
+        state.isLoading = true;
+        state.error = null;
+      })
+      .addCase(fetchSegments.fulfilled, (state, action) => {
+        // console.log("Action Payload:", action.payload);
+        state.data = action.payload;
+        state.isLoading = false;
+      })
+      .addCase(fetchSegments.rejected, (state, action) => {
+        state.error = action.payload;
+        state.isLoading = false;
+      });
+  },
+});
+
+export default visitorSegmentsSlice.reducer;

--- a/frontend/src/store/visitorSegmentsSlice.js
+++ b/frontend/src/store/visitorSegmentsSlice.js
@@ -7,9 +7,15 @@ export const fetchSegments = createAsyncThunk(
   async (_, { rejectWithValue }) => {
     try {
       const response = await fetchContactSegments();
-      const segmentNames = Object.values(response.segments).map((segment) => segment.name);
+      const segmentNames = response.segments 
+        ? Object.values(response.segments).map((segment) => segment.name)
+        : [];
+      
+      console.log("Extracted Visitor Segment Names:", segmentNames);
+      
       return segmentNames;
     } catch (err) {
+      console.error("Visitor Segments Fetch Error:", err);
       return rejectWithValue(err.message);
     }
   }


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-89](https://edu-team4-react24k.atlassian.net/browse/DRD-89?atlOrigin=eyJpIjoiMmZkYWJlNGJkYzE3NDBjMWIyZDk0MjUwNDRhOTM3MjkiLCJwIjoiaiJ9)
## In this PR:
- Installed new frontend dependencies Redux and Redux Toolkit (to save visitor segments in a redux state)
- Refactored ParagraphRenderer to check if user is in required segment before rendering paragraph
## Testing instructions:
- Checkout branch
- do `npm install` in `frontend`
- In Drupal, create paragraphs with different segments selected (i tested this in a project case content)
- If the contact you are browsing as does not belong to a segment required by the paragraph, it should not be rendered
- Notice: If paragraph has multiple segments selected, this current implementation renders the paragraph if visitor belongs to ANY of those segments

## Known issues
- Paragraphs are needlessly re-rendered: first round without visitor segments array or paragraph segments array present, then paragraph segments are fetched, then another render round with empty arrays, and then finally a round of renders with both arrays present.
Me, ChatGPT or Claude could not figure this out yet.
- There is a noticeable delay between opening the page and the paragraphs appearing 

![Screenshot 2024-11-27 at 14 09 32](https://github.com/user-attachments/assets/ef3f48da-db0b-4969-82c6-8121f1f7240a)


[DRD-89]: https://edu-team4-react24k.atlassian.net/browse/DRD-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ