### PR TITLE
DRD-51: Fix fetching image Alt text from JSONAPI

### DIFF
--- a/frontend/src/components/ProjectCard.jsx
+++ b/frontend/src/components/ProjectCard.jsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 
 const ProjectCard = ({ project }) => {
-  const { title, customer, description, heroImageUrl } = project;
+  const { customer, description, heroImageUrl, heroImageAltText } = project;
   const companyName = customer?.toLowerCase().replace(/\s+/g, "-");
 
   return (
@@ -9,7 +9,7 @@ const ProjectCard = ({ project }) => {
       {heroImageUrl ? (
         <img
           src={heroImageUrl}
-          alt={title}
+          alt={heroImageAltText}
           className="w-full h-48 object-cover"
         />
       ) : (

--- a/frontend/src/components/ProjectContainer.jsx
+++ b/frontend/src/components/ProjectContainer.jsx
@@ -30,6 +30,8 @@ const ProjectContainer = () => {
           const heroImageUrl = heroImage
             ? `${drupalLocalhostAddress}${heroImage.attributes.uri.url}`
             : null;
+          const heroImageAltText =
+            project.relationships.field_heroimg?.data?.meta?.alt;
 
           // Process paragraphs in field_content relationship
           const paragraphs =
@@ -58,6 +60,7 @@ const ProjectContainer = () => {
             customer: field_customer,
             description: field_project_description,
             heroImageUrl,
+            heroImageAltText,
             paragraphs,
           };
         });

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -27,7 +27,7 @@ const About = () => {
         ].join(",");
 
         const url = `${drupalLocalhostAddress}/jsonapi/node/about_us?include=${includes}`;
-
+        // console.log(url);
         const response = await fetch(url);
         const data = await response.json();
 
@@ -41,6 +41,7 @@ const About = () => {
           // Find the image
           const imageMediaId =
             aboutPage.relationships.field_image_about?.data?.id;
+
           const imageMedia = data.included?.find(
             (item) => item.id === imageMediaId && item.type === "media--image"
           );
@@ -49,6 +50,9 @@ const About = () => {
           const imageFile = data.included?.find(
             (item) => item.id === imageFileId && item.type === "file--file"
           );
+          const heroImageAltText =
+            imageMedia.relationships?.field_media_image?.data?.meta?.alt ||
+            "About us hero image";
 
           // Construct image URL
           const imageUrl = imageFile
@@ -64,6 +68,7 @@ const About = () => {
 
           setAboutData({
             ...aboutPage,
+            heroImageAltText,
             paragraphs,
           });
           setImageUrl(imageUrl);
@@ -98,7 +103,7 @@ const About = () => {
     <Section>
       <SectionHeading>{aboutData.attributes.title}</SectionHeading>
       {imageUrl && (
-        <HeroImage src={imageUrl} alt={aboutData.attributes.title} />
+        <HeroImage src={imageUrl} altText={aboutData?.heroImageAltText} />
       )}
       <ProseWrapper>
         <div

--- a/frontend/src/pages/Contact.jsx
+++ b/frontend/src/pages/Contact.jsx
@@ -49,7 +49,6 @@ const Contact = () => {
   const imageData = content?.relationships?.field_image?.data;
   // Find the image file in included data based on the ID
   const imageFile = included?.find((image) => image.id === imageData?.id);
-  console.log(imageFile);
   const imageUrl = imageFile
     ? `${drupalLocalhostAddress}${imageFile.attributes.uri.url}`
     : null;

--- a/frontend/src/pages/Contact.jsx
+++ b/frontend/src/pages/Contact.jsx
@@ -49,15 +49,19 @@ const Contact = () => {
   const imageData = content?.relationships?.field_image?.data;
   // Find the image file in included data based on the ID
   const imageFile = included?.find((image) => image.id === imageData?.id);
+  console.log(imageFile);
   const imageUrl = imageFile
     ? `${drupalLocalhostAddress}${imageFile.attributes.uri.url}`
     : null;
-  // TODO: imageAltText is not fetched for some reason
-  const imageAltText = imageFile?.meta?.alt;
 
   return (
     <Section>
-      {imageUrl && <HeroImage src={imageUrl} alt={imageAltText} />}
+      {imageUrl && (
+        <HeroImage
+          src={imageUrl}
+          altText={content.relationships?.field_image?.data?.meta?.alt}
+        />
+      )}
 
       {content && content.attributes && (
         <SectionHeading>{content.attributes.title}</SectionHeading>

--- a/frontend/src/pages/FrontPage.jsx
+++ b/frontend/src/pages/FrontPage.jsx
@@ -42,7 +42,10 @@ const FrontPage = () => {
           setHeroImageUrl(
             isRelativeUrl ? `${drupalLocalhostAddress}${imageUri}` : imageUri
           );
-          setHeroImageAltText(heroImageFile.meta?.alt || "Hero image");
+          setHeroImageAltText(
+            frontPageContent.relationships.field_heroimg.data.meta?.alt ||
+              "Hero image"
+          );
           console.log(
             "Hero image URL:",
             isRelativeUrl ? `${drupalLocalhostAddress}${imageUri}` : imageUri
@@ -79,7 +82,7 @@ const FrontPage = () => {
       {heroImageUrl ? (
         <HeroImage
           src={heroImageUrl}
-          alt={heroImageAltText}
+          altText={heroImageAltText}
           className="hero-image"
         />
       ) : (

--- a/frontend/src/pages/Jobs.jsx
+++ b/frontend/src/pages/Jobs.jsx
@@ -49,11 +49,14 @@ const Jobs = () => {
     ? `${drupalLocalhostAddress}${imageFile.attributes.uri.url}`
     : null;
 
-  const imageAltText = imageFile?.meta?.alt;
-
   return (
     <Section>
-      {imageUrl && <HeroImage src={imageUrl} alt={imageAltText} />}
+      {imageUrl && (
+        <HeroImage
+          src={imageUrl}
+          altText={content.relationships?.field_image?.data?.meta?.alt}
+        />
+      )}
       {content && content.attributes && (
         <SectionHeading>{content.attributes.title}</SectionHeading>
       )}

--- a/frontend/src/pages/OurServices.jsx
+++ b/frontend/src/pages/OurServices.jsx
@@ -72,7 +72,12 @@ const OurServices = () => {
               <Link to={`/service/${serviceType}`} className="block">
                 {item.heroImageUrl && (
                   <div>
-                    <HeroImage src={item.heroImageUrl} />
+                    <HeroImage
+                      src={item.heroImageUrl}
+                      altText={
+                        item.relationships.field_hero_image?.data?.meta.alt
+                      }
+                    />
                     <SectionHeading>{item.attributes.title}</SectionHeading>
                   </div>
                 )}

--- a/frontend/src/pages/ProjectCasePage.jsx
+++ b/frontend/src/pages/ProjectCasePage.jsx
@@ -48,9 +48,13 @@ const ProjectCasePage = () => {
           const heroImage = data.included?.find(
             (img) => img.id === heroImageId && img.type === "file--file"
           );
+
           const heroImageUrl = heroImage
             ? `${drupalLocalhostAddress}${heroImage.attributes.uri.url}`
             : null;
+
+          const heroImageAltText =
+            projectDetail.relationships.field_heroimg?.data?.meta?.alt;
 
           // Process paragraphs while keeping the full paragraph data
           const paragraphs = projectDetail.relationships.field_content?.data
@@ -74,6 +78,7 @@ const ProjectCasePage = () => {
             customer: field_customer,
             description: field_project_description,
             heroImageUrl,
+            heroImageAltText,
             paragraphs,
           });
           setIncluded(data.included || []);
@@ -117,7 +122,10 @@ const ProjectCasePage = () => {
     <Section>
       {" "}
       {project.heroImageUrl && (
-        <HeroImage src={project.heroImageUrl} alt={project.title} />
+        <HeroImage
+          src={project.heroImageUrl}
+          altText={project.heroImageAltText}
+        />
       )}
       <header className="mb-8">
         <SectionHeading>{project.customer}</SectionHeading>

--- a/frontend/src/pages/ServiceDetail.jsx
+++ b/frontend/src/pages/ServiceDetail.jsx
@@ -54,7 +54,7 @@ const ServiceDetail = () => {
         {getHeroImageUrl(data) && (
           <HeroImage
             src={getHeroImageUrl(data)}
-            alt="Service Hero"
+            altText={service.relationships?.field_hero_image?.data?.meta?.alt}
             className="hero-image"
           />
         )}


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-51](https://edu-team4-react24k.atlassian.net/browse/DRD-51?atlOrigin=eyJpIjoiMDc2YWFhZTdlMGZkNGRmOWE0YTQ2YWU3Yzg0MjQ1ZGEiLCJwIjoiaiJ9)
## In this PR:
- Fixed all hero image alt texts (data coming in from jsonapi fetch)
## Testing instructions:
- Checkout branch
- All hero images (meaning images not in paragraphs) should display alt text correctly (use browser tools Inspect element -tool)


[DRD-51]: https://edu-team4-react24k.atlassian.net/browse/DRD-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ