### PR TITLE
DRD-97: TextWithImageParagraph - render "title" field

### DIFF
--- a/frontend/src/components/HeroImage.jsx
+++ b/frontend/src/components/HeroImage.jsx
@@ -1,6 +1,3 @@
-// src/components/Image.jsx
-import PropTypes from "prop-types";
-
 const HeroImage = ({ src, altText }) => {
   return (
     <img
@@ -9,11 +6,6 @@ const HeroImage = ({ src, altText }) => {
       className={`w-full h-64 object-cover rounded-md mb-6`}
     />
   );
-};
-
-HeroImage.propTypes = {
-  src: PropTypes.string.isRequired,
-  altText: PropTypes.string,
 };
 
 export default HeroImage;

--- a/frontend/src/components/ProseWrapper.jsx
+++ b/frontend/src/components/ProseWrapper.jsx
@@ -1,11 +1,5 @@
-import PropTypes from "prop-types";
-
 const ProseWrapper = ({ children }) => {
   return <div className="prose prose-lg text-gray-700">{children}</div>;
 };
 
-// To stop vscode from complaining about passed children
-ProseWrapper.propTypes = {
-  children: PropTypes.node,
-};
 export default ProseWrapper;

--- a/frontend/src/components/Section.jsx
+++ b/frontend/src/components/Section.jsx
@@ -1,5 +1,3 @@
-import PropTypes from "prop-types";
-
 const Section = ({ children }) => {
   return (
     <section className="max-w-3xl mx-auto p-6 bg-white shadow-lg mt-4">
@@ -8,8 +6,4 @@ const Section = ({ children }) => {
   );
 };
 
-// To stop vscode from complaining about passed children
-Section.propTypes = {
-  children: PropTypes.node,
-};
 export default Section;

--- a/frontend/src/components/SectionHeading.jsx
+++ b/frontend/src/components/SectionHeading.jsx
@@ -1,11 +1,5 @@
-import PropTypes from "prop-types";
-
 const SectionHeading = ({ children }) => {
   return <h1 className="text-3xl font-bold mb-4">{children}</h1>;
 };
 
-// To stop vscode from complaining about passed children
-SectionHeading.propTypes = {
-  children: PropTypes.node,
-};
 export default SectionHeading;

--- a/frontend/src/components/TextWithImageParagraph.jsx
+++ b/frontend/src/components/TextWithImageParagraph.jsx
@@ -1,5 +1,6 @@
 import DOMPurify from "dompurify";
 import { findImageUrl } from "../services/utils";
+import SectionHeading from "./SectionHeading";
 
 const TextWithImageParagraph = ({ paragraph, included }) => {
   const imageUrl = findImageUrl(paragraph.relationships?.field_image, included);
@@ -8,37 +9,37 @@ const TextWithImageParagraph = ({ paragraph, included }) => {
   const isImageFirst = paragraph.attributes?.field_image_first || false;
 
   return (
-    <div className="flex flex-col md:flex-row items-center gap-6">
-      {isImageFirst && imageUrl && (
+    <>
+      <SectionHeading>{paragraph.attributes?.field_title || ""}</SectionHeading>
+      <div className="flex flex-col md:flex-row items-center gap-6">
+        {isImageFirst && imageUrl && (
+          <div className="md:w-1/2">
+            <img
+              src={imageUrl}
+              alt={paragraph.attributes?.field_title || "Project image"}
+              className="max-w-full h-auto rounded-lg shadow-md"
+            />
+          </div>
+        )}
         <div className="md:w-1/2">
-          <img
-            src={imageUrl}
-            alt={paragraph.attributes?.field_heading || "Project image"}
-            className="max-w-full h-auto rounded-lg shadow-md"
+          <div
+            className="prose"
+            dangerouslySetInnerHTML={{
+              __html: DOMPurify.sanitize(paragraph.attributes?.field_long_text),
+            }}
           />
         </div>
-      )}
-      <div className="md:w-1/2">
-        <h3 className="font-semibold">
-          {paragraph.attributes?.field_heading || ""}
-        </h3>
-        <div
-          className="prose"
-          dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(paragraph.attributes?.field_long_text),
-          }}
-        />
+        {!isImageFirst && imageUrl && (
+          <div className="md:w-1/2">
+            <img
+              src={imageUrl}
+              alt={paragraph.attributes?.field_title || "Project image"}
+              className="max-w-full h-auto rounded-lg shadow-md"
+            />
+          </div>
+        )}
       </div>
-      {!isImageFirst && imageUrl && (
-        <div className="md:w-1/2">
-          <img
-            src={imageUrl}
-            alt={paragraph.attributes?.field_heading || "Project image"}
-            className="max-w-full h-auto rounded-lg shadow-md"
-          />
-        </div>
-      )}
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-97](https://edu-team4-react24k.atlassian.net/browse/DRD-97?atlOrigin=eyJpIjoiZWZkZjhjZDgxMGI5NDM0YmFmZTFjNDI5Yzc4YjA5OGUiLCJwIjoiaiJ9)
## In this PR:
- Refactored TextWithImageParagraph component to render "title" field from Drupal
- Removed redundant prop type declarations from components (now handled in eslint config)
## Testing instructions:
- Checkout branch
- Create a text with image paragraph in Drupal (in about page or a project case for example)
- Title should be rendered as a heading
<img width="768" alt="Screenshot 2024-12-02 at 12 47 37" src="https://github.com/user-attachments/assets/f9cdaa60-7888-4530-a996-87d763b7cda6">


[DRD-97]: https://edu-team4-react24k.atlassian.net/browse/DRD-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ