### PR TITLE
DRD-92: Images in paragraphs: fetch and use the alt text

### DIFF
--- a/frontend/src/components/ImageParagraph.jsx
+++ b/frontend/src/components/ImageParagraph.jsx
@@ -1,17 +1,20 @@
 import { findImageUrl } from "../services/utils";
 
 const ImageParagraph = ({ paragraph, included }) => {
-  const imageUrl = findImageUrl(paragraph.relationships?.field_image, included);
+  const { imageUrl, altText } = findImageUrl(
+    paragraph.relationships?.field_image,
+    included
+  );
 
   return (
     <div>
       <h3 className="font-semibold">
-        {paragraph.attributes?.field_heading || ""}
+        {paragraph.attributes?.field_title || ""}
       </h3>
       {imageUrl && (
         <img
           src={imageUrl}
-          alt={paragraph.attributes?.field_heading || "Project image"}
+          alt={altText || "n/a"}
           className="mt-4 max-w-full h-auto rounded-lg shadow-md"
         />
       )}

--- a/frontend/src/components/TextWithImageParagraph.jsx
+++ b/frontend/src/components/TextWithImageParagraph.jsx
@@ -3,7 +3,10 @@ import { findImageUrl } from "../services/utils";
 import SectionHeading from "./SectionHeading";
 
 const TextWithImageParagraph = ({ paragraph, included }) => {
-  const imageUrl = findImageUrl(paragraph.relationships?.field_image, included);
+  const { imageUrl, altText } = findImageUrl(
+    paragraph.relationships?.field_image,
+    included
+  );
 
   // Check if toggle "field_image_first" is set to true or false by user in drupal paragraph:
   const isImageFirst = paragraph.attributes?.field_image_first || false;
@@ -16,7 +19,7 @@ const TextWithImageParagraph = ({ paragraph, included }) => {
           <div className="md:w-1/2">
             <img
               src={imageUrl}
-              alt={paragraph.attributes?.field_title || "Project image"}
+              alt={altText || "n/a"}
               className="max-w-full h-auto rounded-lg shadow-md"
             />
           </div>
@@ -33,7 +36,7 @@ const TextWithImageParagraph = ({ paragraph, included }) => {
           <div className="md:w-1/2">
             <img
               src={imageUrl}
-              alt={paragraph.attributes?.field_title || "Project image"}
+              alt={altText || "n/a"}
               className="max-w-full h-auto rounded-lg shadow-md"
             />
           </div>

--- a/frontend/src/services/utils.js
+++ b/frontend/src/services/utils.js
@@ -2,13 +2,13 @@ import { drupalLocalhostAddress } from "./api";
 
 export const findImageUrl = (fieldImage, included) => {
   if (!fieldImage || !included) {
-    return null;
+    return { imageUrl: null, altText: "n/a" };
   }
 
   // Get the media entity ID from the paragraph's field_image relationship
   const mediaEntityId = fieldImage.data?.id;
   if (!mediaEntityId) {
-    return null;
+    return { imageUrl: null, altText: "n/a" };
   }
 
   // Find the media entity
@@ -16,13 +16,16 @@ export const findImageUrl = (fieldImage, included) => {
     (item) => item.type === "media--image" && item.id === mediaEntityId
   );
   if (!mediaEntity) {
-    return null;
+    return { imageUrl: null, altText: "n/a" };
   }
+  console.log("mediaEntity log", mediaEntity);
+
+  const altText = mediaEntity.relationships?.field_media_image?.data?.meta?.alt || "n/a";
 
   // Get the file ID from the media entity's field_media_image relationship
   const fileId = mediaEntity.relationships?.field_media_image?.data?.id;
   if (!fileId) {
-    return null;
+    return { imageUrl: null, altText};
   }
 
   // Find the file entity
@@ -30,12 +33,16 @@ export const findImageUrl = (fieldImage, included) => {
     (item) => item.type === "file--file" && item.id === fileId
   );
 
-  if (fileEntity?.attributes?.uri?.url) {
-    const fullUrl = `${drupalLocalhostAddress}${fileEntity.attributes.uri.url}`;
+  // Extract the image URL
+  const imageUrl = fileEntity?.attributes?.uri?.url
+    ? `${drupalLocalhostAddress}${fileEntity.attributes.uri.url}`
+    : null;
+    console.log({ imageUrl, altText });
 
-    return fullUrl;
-  }
-  return null;
+    return {
+      imageUrl,
+      altText,
+    }
 };
 
 // Helper function to capitalize the first letter of each word (for dynamic page title in App.jsx)


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-92](https://edu-team4-react24k.atlassian.net/browse/DRD-92?atlOrigin=eyJpIjoiNTFlMGFiZmM3MjFkNDJlMzg0YzZhOWZmZTIwODMyM2EiLCJwIjoiaiJ9)
## In this PR:
- Refactored findImageUrl function to return an object with imageUrl and altText
- Use returned altText in ImageParagraph.jsx and TextWithImageParagraph.jsx
## Testing instructions:
- Checkout branch
- Use browser tool inspect element to check that images in paragraphs have the correct alt text
- Notice: alt text for Media images is given when the user uploads them. It can be seen in Drupal: Content -> Media -> click on one.

[DRD-92]: https://edu-team4-react24k.atlassian.net/browse/DRD-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ