### PR TITLE
DRD-108: Fix "<link rel=preload> must have a valid `as` value" console warning

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" href="/logoiv.ico" type="image/x-icon" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preload"
-      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=arrow_forward"
-    />
-    <title>Druid - Team 4</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" href="/logoiv.ico" type="image/x-icon" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="preconnect" href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap"
+    rel="stylesheet" />
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=arrow_forward" />
+  <title>Druid - Team 4</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+
 </html>


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-108](https://edu-team4-react24k.atlassian.net/browse/DRD-108?atlOrigin=eyJpIjoiYjU5MmMzZmQyZDJmNDljZTgxZDA1MzA4MTdkOTMzYWYiLCJwIjoiaiJ9)
## In this PR:
- Replace 'preload' with 'preconnect' for font in index.html (recommended for google fonts)
## Testing instructions:
- Checkout branch
- You should no longer see console warning "<link rel=preload> must have a valid `as` value"


[DRD-108]: https://edu-team4-react24k.atlassian.net/browse/DRD-108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ