### PR TITLE
DRD-112: Style main page hero banners to match Careers page

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -52,7 +52,7 @@ const Header = () => {
     "w-full md:w-auto text-center md:text-left md:text-base md:font-normal";
 
   return (
-    <header className="flex items-center justify-between p-4 bg-gray-800 text-white font-sans md:border-b md:border-gray-300">
+    <header className="flex items-center justify-between p-4 bg-gray-800 text-white font-sans">
       <div className="flex items-center">
         <Link to="/">
           <img

--- a/frontend/src/components/HeroHeader.jsx
+++ b/frontend/src/components/HeroHeader.jsx
@@ -8,7 +8,7 @@ const HeroHeader = ({ imageUrl, content }) => {
     >
       <div className="flex flex-col justify-center items-center p-4">
         {content?.attributes?.title && (
-          <h1 className="text-5xl font-sans font-semibold text-white text-center max-w-2xl leading-tight">
+          <h1 className="text-5xl font-sans font-semibold text-white text-center max-w-3xl leading-tight">
             {content.attributes.title}
           </h1>
         )}

--- a/frontend/src/components/HeroHeader.jsx
+++ b/frontend/src/components/HeroHeader.jsx
@@ -1,0 +1,20 @@
+const HeroHeader = ({ imageUrl, content }) => {
+  return (
+    <div
+      className="h-96 bg-cover bg-center flex justify-center items-center"
+      style={{
+        backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(${imageUrl})`,
+      }}
+    >
+      <div className="flex flex-col justify-center items-center p-4">
+        {content?.attributes?.title && (
+          <h1 className="text-5xl font-sans font-semibold text-white text-center max-w-2xl leading-tight">
+            {content.attributes.title}
+          </h1>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default HeroHeader;

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -1,10 +1,9 @@
 import { useState, useEffect } from "react";
 import { drupalLocalhostAddress } from "../services/api";
 import Section from "../components/Section";
-import SectionHeading from "../components/SectionHeading";
-import HeroImage from "../components/HeroImage";
 import ParagraphRenderer from "../components/ParagraphRenderer";
 import "../css/AboutCards.css";
+import HeroHeader from "../components/HeroHeader";
 
 const About = () => {
   const [aboutData, setAboutData] = useState(null);
@@ -99,50 +98,50 @@ const About = () => {
   }
 
   return (
-    <Section>
-      {imageUrl && (
-        <HeroImage src={imageUrl} altText={aboutData?.heroImageAltText} />
-      )}
-      <SectionHeading>{aboutData.attributes.title}</SectionHeading>
-      <div
-        className="mx-auto my-8 prose"
-        dangerouslySetInnerHTML={{
-          __html: aboutData.attributes.field_about_body.processed,
-        }}
-      />
-
-      <div className="about-cards">
-        {aboutData.paragraphs &&
-          aboutData.paragraphs.map((paragraph, index) => (
-            <ParagraphRenderer
-              key={index}
-              paragraph={paragraph}
-              included={included}
-            />
-          ))}
-      </div>
-
-      <h2 className="section-title">Druid in numbers</h2>
-      <div className="info-cards">
-        <div className="card">
-          <h3 className="card-value">
-            {aboutData.attributes.field_annual_turnover}
-          </h3>
-          <p className="card-label">Annual Turnover</p>
+    <>
+      <HeroHeader imageUrl={imageUrl} content={aboutData} />
+      <Section>
+        <div
+          className="mx-auto my-8 prose"
+          dangerouslySetInnerHTML={{
+            __html: aboutData.attributes.field_about_body.processed,
+          }}
+        />
+        <div className="about-cards">
+          {aboutData.paragraphs &&
+            aboutData.paragraphs.map((paragraph, index) => (
+              <ParagraphRenderer
+                key={index}
+                paragraph={paragraph}
+                included={included}
+              />
+            ))}
         </div>
 
-        <div className="card">
-          <h3 className="card-value">{aboutData.attributes.field_employees}</h3>
-          <p className="card-label">Employees</p>
+        <h2 className="section-title">Druid in numbers</h2>
+        <div className="info-cards">
+          <div className="card">
+            <h3 className="card-value">
+              {aboutData.attributes.field_annual_turnover}
+            </h3>
+            <p className="card-label">Annual Turnover</p>
+          </div>
+
+          <div className="card">
+            <h3 className="card-value">
+              {aboutData.attributes.field_employees}
+            </h3>
+            <p className="card-label">Employees</p>
+          </div>
+          <div className="card">
+            <h3 className="card-value">
+              {aboutData.attributes.field_completed_projects}
+            </h3>
+            <p className="card-label">Completed Projects</p>
+          </div>
         </div>
-        <div className="card">
-          <h3 className="card-value">
-            {aboutData.attributes.field_completed_projects}
-          </h3>
-          <p className="card-label">Completed Projects</p>
-        </div>
-      </div>
-    </Section>
+      </Section>
+    </>
   );
 };
 

--- a/frontend/src/pages/Contact.jsx
+++ b/frontend/src/pages/Contact.jsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
 import { fetchContent, drupalLocalhostAddress } from "../services/api";
 import Section from "../components/Section";
-import HeroImage from "../components/HeroImage";
 import SectionHeading from "../components/SectionHeading";
 import ProseWrapper from "../components/ProseWrapper";
 import DOMPurify from "dompurify";
 import MauticContactForm from "../components/MauticContactForm";
+import HeroHeader from "../components/HeroHeader";
 
 const Contact = () => {
   const [content, setContent] = useState(null);
@@ -72,37 +72,31 @@ const Contact = () => {
     : null;
 
   return (
-    <Section>
-      {imageUrl && (
-        <HeroImage
-          src={imageUrl}
-          altText={content.relationships?.field_image?.data?.meta?.alt}
-        />
-      )}
+    <>
+      <HeroHeader imageUrl={imageUrl} content={content} />
+      <Section>
+        <ProseWrapper>
+          {sanitizedDrupalContent ? (
+            <div
+              dangerouslySetInnerHTML={{
+                __html: sanitizedDrupalContent,
+              }}
+            />
+          ) : (
+            <div className="text-center text-gray-500">
+              No content available
+            </div>
+          )}
+        </ProseWrapper>
+        <SectionHeading>Contact Us</SectionHeading>
 
-      {content && content.attributes && (
-        <SectionHeading>{content.attributes.title}</SectionHeading>
-      )}
-
-      <ProseWrapper>
-        {sanitizedDrupalContent ? (
-          <div
-            dangerouslySetInnerHTML={{
-              __html: sanitizedDrupalContent,
-            }}
-          />
+        {formId ? (
+          <MauticContactForm formId={formId} />
         ) : (
-          <div className="text-center text-gray-500">No content available</div>
+          <div className="text-center text-gray-500">Form not available</div>
         )}
-      </ProseWrapper>
-      <SectionHeading>Contact Us</SectionHeading>
-
-      {formId ? (
-        <MauticContactForm formId={formId} />
-      ) : (
-        <div className="text-center text-gray-500">Form not available</div>
-      )}
-    </Section>
+      </Section>
+    </>
   );
 };
 

--- a/frontend/src/pages/FrontPage.jsx
+++ b/frontend/src/pages/FrontPage.jsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { drupalLocalhostAddress } from "../services/api";
 import Section from "../components/Section";
-import SectionHeading from "../components/SectionHeading";
-import HeroImage from "../components/HeroImage";
 import ProseWrapper from "../components/ProseWrapper";
 import ParagraphRenderer from "../components/ParagraphRenderer";
 import ProjectContainer from "../components/ProjectContainer";
+import HeroHeader from "../components/HeroHeader";
 
 const FrontPage = () => {
   const [frontPageData, setFrontPageData] = useState(null);
@@ -98,43 +97,38 @@ const FrontPage = () => {
   }
 
   return (
-    <Section>
-      {heroImageUrl && (
-        <HeroImage
-          src={heroImageUrl}
-          altText={heroImageAltText}
-          className="hero-image"
-        />
-      )}
-      <SectionHeading>{frontPageData.attributes.title}</SectionHeading>
-      {frontPageData.attributes.field_description && (
-        <p className="short-description">
-          {frontPageData.attributes.field_description}
-        </p>
-      )}
-      <ProseWrapper>
-        {frontPageData.attributes.body && (
-          <div
-            dangerouslySetInnerHTML={{
-              __html: frontPageData.attributes.body.processed,
-            }}
-          />
+    <>
+      <HeroHeader imageUrl={heroImageUrl} content={frontPageData} />
+      <Section>
+        {frontPageData.attributes.field_description && (
+          <p className="short-description">
+            {frontPageData.attributes.field_description}
+          </p>
         )}
-      </ProseWrapper>
-
-      <div className="front-page-content">
-        {frontPageData.paragraphs &&
-          frontPageData.paragraphs.map((paragraph, index) => (
-            <ParagraphRenderer
-              key={index}
-              paragraph={paragraph}
-              included={included}
+        <ProseWrapper>
+          {frontPageData.attributes.body && (
+            <div
+              dangerouslySetInnerHTML={{
+                __html: frontPageData.attributes.body.processed,
+              }}
             />
-          ))}
-      </div>
+          )}
+        </ProseWrapper>
 
-      <ProjectContainer />
-    </Section>
+        <div className="front-page-content">
+          {frontPageData.paragraphs &&
+            frontPageData.paragraphs.map((paragraph, index) => (
+              <ParagraphRenderer
+                key={index}
+                paragraph={paragraph}
+                included={included}
+              />
+            ))}
+        </div>
+
+        <ProjectContainer />
+      </Section>
+    </>
   );
 };
 

--- a/frontend/src/pages/Jobs.jsx
+++ b/frontend/src/pages/Jobs.jsx
@@ -5,6 +5,7 @@ import Section from "../components/Section";
 import SectionHeading from "../components/SectionHeading";
 import ProseWrapper from "../components/ProseWrapper";
 import DOMPurify from "dompurify";
+import HeroHeader from "../components/HeroHeader";
 
 const Jobs = () => {
   const [content, setContent] = useState(null);
@@ -51,21 +52,7 @@ const Jobs = () => {
 
   return (
     <>
-      <div
-        className="h-96 bg-cover bg-center flex justify-center items-center"
-        style={{
-          backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(${imageUrl})`,
-        }}
-      >
-        <div className="flex flex-col justify-center items-center container mx-auto p-4 pt-6 md:p-6 lg:px-16 xl:px-20">
-          {content && content.attributes && (
-            <h1 className="text-5xl font-bold text-white">
-              {content.attributes.title}
-            </h1>
-          )}
-        </div>
-      </div>
-
+      <HeroHeader imageUrl={imageUrl} content={content} />
       <Section>
         <div className="flex flex-col items-center justify-center">
           <ProseWrapper>


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-112](https://edu-team4-react24k.atlassian.net/browse/DRD-112?atlOrigin=eyJpIjoiNWM3NzhkZGM1NjdhNGJiNWFjNWEyZGUzNjdhMDVjNGQiLCJwIjoiaiJ9)
## In this PR:
- Created new component HeroHeader (moved code from Careers page to this component)
- Used HeroHeader to style main pages with hero images (front page, about, contact) to match Careers page
- Removed bottom border from Header
## Testing instructions:
- Checkout branch
- Check that pages front page, about and contact match Careers page

<img width="1422" alt="Screenshot 2024-12-12 at 11 00 52" src="https://github.com/user-attachments/assets/c9e99bb0-bb97-47b6-aaf8-c0b3efa4d7b2" />



[DRD-112]: https://edu-team4-react24k.atlassian.net/browse/DRD-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ