### PR TITLE
DRD-118: remove hardcoded image, add font size breakpoints for short description

### DIFF
--- a/conf/field.storage.node.field_content.yml
+++ b/conf/field.storage.node.field_content.yml
@@ -14,7 +14,7 @@ settings:
   target_type: paragraph
 module: entity_reference_revisions
 locked: false
-cardinality: 5
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/frontend/src/pages/FrontPage.jsx
+++ b/frontend/src/pages/FrontPage.jsx
@@ -106,9 +106,9 @@ const FrontPage = () => {
     <>
       <HeroHeader imageUrl={heroImageUrl} content={frontPageData} />
       <Section>
-        <div className="w-3/4 text-center p-10 mx-auto mb-5">
+        <div className="text-center p-5 m-5">
           {frontPageData.attributes.field_description && (
-            <p className="short-description lg:text-4xl md:text-3xl sm:text-xl p-10">
+            <p className="short-description lg:text-4xl md:text-3xl sm:text-2xl p-10">
               {frontPageData.attributes.field_description}
             </p>
           )}

--- a/frontend/src/pages/FrontPage.jsx
+++ b/frontend/src/pages/FrontPage.jsx
@@ -108,19 +108,12 @@ const FrontPage = () => {
       <Section>
         <div className="w-3/4 text-center p-10 mx-auto mb-5">
           {frontPageData.attributes.field_description && (
-            <p className="short-description text-4xl p-10">
+            <p className="short-description lg:text-4xl md:text-3xl sm:text-xl p-10">
               {frontPageData.attributes.field_description}
             </p>
           )}
         </div>
         <div className="flex w-full justify-center mt-6">
-          {/* added the picture directly here because I couldn't figure out how to do it from drupal */}
-          <img
-            src={groupPicture}
-            alt="Druid's founders Samuli, Tero, Arto and Roni with our Production Director Pasi"
-            className="w-1/2 h-full rounded-lg shadow-md"
-          ></img>
-
           <ProseWrapper className="w-3/4">
             {frontPageData.attributes.body && (
               <div


### PR DESCRIPTION
## Related ticket
[DRD-118](https://edu-team4-react24k.atlassian.net/jira/software/projects/DRD/boards/1?selectedIssue=DRD-118)

## In this PR: 
- removed hardcoded image and added a new text with image paragraph in Drupal instead
- added font size breakpoints for short description in the front page
- edit padding and margin
- export new db and configs

## Testing instructions 
- checkout branch
- lando drush cim
- lando db-import DRD-118.sql.gz
- Check front page that short description font size changes on smaller screens 

[DRD-118]: https://edu-team4-react24k.atlassian.net/browse/DRD-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ