### PR TITLE
DRD-119: Increase top margin on HeroHeader

### DIFF
--- a/frontend/src/components/HeroHeader.jsx
+++ b/frontend/src/components/HeroHeader.jsx
@@ -1,14 +1,14 @@
 const HeroHeader = ({ imageUrl, content }) => {
   return (
     <div
-      className="h-96 bg-cover bg-center flex justify-center items-center"
+      className="h-96 mt-16 bg-cover bg-center flex justify-center items-center"
       style={{
         backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(${imageUrl})`,
       }}
     >
       <div className="flex flex-col justify-center items-center p-4">
         {content?.attributes?.title && (
-          <h1 className="text-5xl font-sans font-semibold text-white text-center max-w-3xl leading-tight">
+          <h1 className="text-3xl md:text-4xl lg:text-5xl font-sans font-semibold text-white text-center max-w-3xl leading-tight">
             {content.attributes.title}
           </h1>
         )}


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-119](https://edu-team4-react24k.atlassian.net/browse/DRD-119?atlOrigin=eyJpIjoiMjZkMzkyMmYxN2E1NDMxZDk3NGYwZTk3Y2Q1YWQ4OWMiLCJwIjoiaiJ9)
## In this PR:
- Increased top margin in HeroHeader
- Added font size breakpoints for HeroHeader title text
## Testing instructions:
- Checkout branch
- Check that HeroHeaders look ok in all resolutions on pages that have it

[DRD-119]: https://edu-team4-react24k.atlassian.net/browse/DRD-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ