### PR TITLE
DRD-120: Make Jobs page mobile responsive (About Druid part)

### DIFF
--- a/frontend/src/pages/FrontPage.jsx
+++ b/frontend/src/pages/FrontPage.jsx
@@ -114,13 +114,6 @@ const FrontPage = () => {
           )}
         </div>
         <div className="flex w-full justify-center mt-6">
-          {/* added the picture directly here because I couldn't figure out how to do it from drupal */}
-          <img
-            src={groupPicture}
-            alt="Druid's founders Samuli, Tero, Arto and Roni with our Production Director Pasi"
-            className="w-1/2 h-full rounded-lg shadow-md"
-          ></img>
-
           <ProseWrapper className="w-3/4">
             {frontPageData.attributes.body && (
               <div

--- a/frontend/src/pages/Jobs.jsx
+++ b/frontend/src/pages/Jobs.jsx
@@ -77,21 +77,19 @@ const Jobs = () => {
             )}
           </ProseWrapper>
           {included[1] && included[1].attributes ? (
-            <>
-              <div className="w-full flex flex-col items-center justify-center bg-gray-100 p-3 m-3 rounded-md">
-                <SectionHeading>
-                  {included[1].attributes.field_about_title}
-                </SectionHeading>
-                <ProseWrapper>
-                  <div className="m-2 p-2">
-                    {included[1].attributes.field_about_body.value}
-                  </div>
-                  <div className="m-2 p-2">
-                    {included[2].attributes.field_about_body.value}
-                  </div>
-                </ProseWrapper>
-              </div>
-            </>
+            <div className="w-full flex flex-col items-center justify-center bg-gray-100 p-3 m-3 rounded-md">
+              <SectionHeading>
+                {included[1].attributes.field_about_title}
+              </SectionHeading>
+              <ProseWrapper>
+                <div className="m-2 p-2">
+                  {included[1].attributes.field_about_body.value}
+                </div>
+                <div className="m-2 p-2">
+                  {included[2].attributes.field_about_body.value}
+                </div>
+              </ProseWrapper>
+            </div>
           ) : (
             ""
           )}

--- a/frontend/src/pages/Jobs.jsx
+++ b/frontend/src/pages/Jobs.jsx
@@ -8,7 +8,6 @@ import DOMPurify from "dompurify";
 import { FaArrowRightLong } from "react-icons/fa6";
 import HeroHeader from "../components/HeroHeader";
 
-
 const Jobs = () => {
   const [content, setContent] = useState(null);
   const [included, setIncluded] = useState(null);
@@ -78,21 +77,21 @@ const Jobs = () => {
             )}
           </ProseWrapper>
           {included[1] && included[1].attributes ? (
-            <div className="w-full flex items-center justify-center bg-gray-100 p-3 m-3 rounded-md">
-              <SectionHeading>
-                <span className="m-5 p-2">
+            <>
+              <div className="w-full flex flex-col items-center justify-center bg-gray-100 p-3 m-3 rounded-md">
+                <SectionHeading>
                   {included[1].attributes.field_about_title}
-                </span>
-              </SectionHeading>
-              <ProseWrapper>
-                <div className="m-2 p-2">
-                  {included[1].attributes.field_about_body.value}
-                </div>
-                <div className="m-2 p-2">
-                  {included[2].attributes.field_about_body.value}
-                </div>
-              </ProseWrapper>
-            </div>
+                </SectionHeading>
+                <ProseWrapper>
+                  <div className="m-2 p-2">
+                    {included[1].attributes.field_about_body.value}
+                  </div>
+                  <div className="m-2 p-2">
+                    {included[2].attributes.field_about_body.value}
+                  </div>
+                </ProseWrapper>
+              </div>
+            </>
           ) : (
             ""
           )}


### PR DESCRIPTION
## Related ticket
[DRD-120](https://edu-team4-react24k.atlassian.net/jira/software/projects/DRD/boards/1?selectedIssue=DRD-120)

## In this PR
- changed the About Druid heading to the top of the paragraph and made the div into a flex column so it scales down better on mobile

## Testing instructions
- checkout branch
- test jobs page with small screen resolution
<img width="706" alt="Screenshot 2024-12-16 at 14 10 21" src="https://github.com/user-attachments/assets/255829f7-aa42-4b9b-b789-1918d604b02d" />


[DRD-120]: https://edu-team4-react24k.atlassian.net/browse/DRD-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ