### PR TITLE
DRD-129: ProjectCard: remove line-clamp

### DIFF
--- a/frontend/src/components/ProjectCard.jsx
+++ b/frontend/src/components/ProjectCard.jsx
@@ -5,28 +5,26 @@ const ProjectCard = ({ project }) => {
   const companyName = customer?.toLowerCase().replace(/\s+/g, "-");
 
   return (
-    <div className="bg-white shadow-lg rounded-lg overflow-hidden w-full h-full">
-      {heroImageUrl ? (
-        <img
-          src={heroImageUrl}
-          alt={heroImageAltText}
-          className="w-full h-48 object-cover"
-        />
-      ) : (
-        <div className="w-full h-48 bg-gray-300 flex items-center justify-center text-white">
-          No image available
-        </div>
-      )}
+    <div className="bg-white shadow-lg rounded-lg overflow-hidden w-full h-full flex flex-col">
+      <div className="h-64">
+        {heroImageUrl ? (
+          <img
+            src={heroImageUrl}
+            alt={heroImageAltText}
+            className="w-full h-full object-cover"
+          />
+        ) : null}
+      </div>
 
-      <div className="p-6">
+      <div className="p-6 flex flex-col flex-grow">
         {/* <h2 className="text-xl font-semibold text-gray-800">{title}</h2> */}
         <h3 className="text-xl text-gray-600 mb-2">{customer}</h3>
-        <p className="text-gray-500 text-sm md:text-base line-clamp-3">
-          {description}
+        <p className="text-gray-500 text-sm md:text-base flex-grow mb-3">
+          {description.split(". ").slice(0, 2).join(". ")}
         </p>
         <Link
           to={`/projects/${companyName}`} // Link to the detailed page using company name
-          className="text-orange-500 hover:text-orange-700 mt-4 block text-sm font-semibold"
+          className="text-orange-500 hover:text-orange-700 block text-sm font-semibold mt-auto"
         >
           Read More{" "}
         </Link>

--- a/frontend/src/components/ProjectContainer.jsx
+++ b/frontend/src/components/ProjectContainer.jsx
@@ -77,9 +77,9 @@ const ProjectContainer = () => {
   return (
     <div id="featuredCases" className="container mx-auto mt-10 p-6">
       <h1 className="text-center text-3xl m-5 p-5">Featured projects</h1>
-      <div className="flex flex-wrap justify-start gap-6">
+      <div className="flex flex-wrap justify-center gap-6">
         {projects.map((project) => (
-          <div className="flex-grow sm:w-1/2 md:w-1/3" key={project.id}>
+          <div className="w-full lg:w-[45%]" key={project.id}>
             <ProjectCard project={project} />
           </div>
         ))}


### PR DESCRIPTION
## Related ticket / Customer approval:
[DRD-129](https://edu-team4-react24k.atlassian.net/browse/DRD-129?atlOrigin=eyJpIjoiNjE2NWRlOTAzOWYyNGFlOWJjYjJlMTMxNjE4OTJmMDUiLCJwIjoiaiJ9)
## In this PR:
- Removed line-clamp, display only first two sentences of description
- Styled ProjectCard and ProjectContainer to have equally sized cards, adjusted resolution breakpoints
## Testing instructions:
- Checkout branch
- View project cards in multiple resolutions
- Notice: images appear pixelated because the original resolution is large and they are being shrunk down
![Screenshot 2024-12-18 at 11 34 08](https://github.com/user-attachments/assets/4ec8a3a1-953c-4e67-9501-85a83492308b)


[DRD-129]: https://edu-team4-react24k.atlassian.net/browse/DRD-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ